### PR TITLE
Rerun a submission in error.  Fixes #69.

### DIFF
--- a/web_external/js/views/body/SubmissionView.js
+++ b/web_external/js/views/body/SubmissionView.js
@@ -3,6 +3,17 @@
 */
 covalic.views.SubmissionView = covalic.View.extend({
     events: {
+        'click .c-restart-error-submission-button': function () {
+            // create a new submission with the same properties
+            var submission = new covalic.models.SubmissionModel();
+            submission.on('c:submissionPosted', function () {
+                covalic.router.navigate('submission/' + submission.get('_id'), {trigger: true});
+            }, this).postSubmission({
+                phaseId: this.submission.get('phaseId'),
+                folderId: this.submission.get('folderId'),
+                title: this.submission.get('title')
+            });
+        },
         'click .c-leaderboard-button': function () {
             covalic.router.navigate('phase/' + this.submission.get('phaseId'), {
                 trigger: true

--- a/web_external/js/views/body/SubmissionView.js
+++ b/web_external/js/views/body/SubmissionView.js
@@ -120,7 +120,8 @@ covalic.views.SubmissionView = covalic.View.extend({
     // If an error occurred during processing, we'll display error info.
     _renderProcessingError: function () {
         this.$('.c-submission-display-body').html(covalic.templates.submissionError({
-            job: this.job
+            job: this.job,
+            adminUser: (girder.currentUser && girder.currentUser.get('admin'))
         }));
 
         new girder.views.jobs_JobDetailsWidget({

--- a/web_external/stylesheets/body/submissionPage.styl
+++ b/web_external/stylesheets/body/submissionPage.styl
@@ -71,6 +71,14 @@
   font-weight bold
   font-size 15px
 
+.c-restart-error-submission-button
+  float right
+
+  i
+    font-weight bold
+    font-style normal
+    font-size 16px
+
 .c-user-portrait
   width 64px
   height 64px

--- a/web_external/templates/widgets/submissionError.jade
+++ b/web_external/templates/widgets/submissionError.jade
@@ -1,6 +1,7 @@
 .c-submission-error-header
     | Error processing submission
-    button.c-restart-error-submission-button.btn.btn-small.btn-primary
-        i.icon-cw
-            | Restart Submission
+    if adminUser
+        button.c-restart-error-submission-button.btn.btn-small.btn-primary
+            i.icon-cw
+                | Restart Submission
 .c-job-details-container

--- a/web_external/templates/widgets/submissionError.jade
+++ b/web_external/templates/widgets/submissionError.jade
@@ -1,2 +1,6 @@
-.c-submission-error-header Error processing submission
+.c-submission-error-header
+    | Error processing submission
+    button.c-restart-error-submission-button.btn.btn-small.btn-primary
+        i.icon-cw
+            | Restart Submission
 .c-job-details-container


### PR DESCRIPTION
This creates a new submission with the same properties as the old one.  In the future this may need to be protected by access control if we don't want end users to be able to do it.  For now, this is useful for development/debugging.