### PR TITLE
Fixes #88. Restore proper functioning of phase deletion.

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -124,7 +124,7 @@ def deleteSubmissions(event):
 
     submissions = subModel.find({
         'phaseId': phase['_id']
-    }, limit=0, timeout=False)
+    }, limit=0)
 
     for sub in submissions:
         subModel.remove(sub)


### PR DESCRIPTION
This commit fixes a regression introduced by girder/girder@f34130b (Make
all PyMongo "find" queries not timeout).