### PR TITLE
Use Strict-Transport-Security header

### DIFF
--- a/ansible/roles/girder/templates/nginx_prod.j2
+++ b/ansible/roles/girder/templates/nginx_prod.j2
@@ -9,7 +9,7 @@ server {
     listen 443 ssl;
     ssl_certificate /etc/nginx/ssl/challenge_kitware_com.pem;
     ssl_certificate_key /etc/nginx/ssl/challenge.kitware.com.key;
-
+    add_header Strict-Transport-Security "max-age=15552000";
     root {{ girder_root }}/clients/web;
 
     # Make site accessible from http://localhost/


### PR DESCRIPTION
This instructs browsers to always attempt to use https to access this domain.

@mgrauer PTAL, I already deployed this onto challenge.kitware.com and it seems to be working.