### PR TITLE
Fix ansible Restart Docker Daemon task

### DIFF
--- a/ansible/roles/celery/tasks/main.yml
+++ b/ansible/roles/celery/tasks/main.yml
@@ -109,7 +109,7 @@
   tags: celery
 
 - name: Restart docker daemon
-  service: name=docker.io state=restarted enabled=yes
+  service: name=docker state=restarted enabled=yes
   sudo: yes
   tags:
     - celery


### PR DESCRIPTION
Running "vagrant up" failed with an error when running the "Restart
Docker Daemon" task because the name of the docker service was
incorrect. This commit corrects the name of the service.