### PR TITLE
Fix Submission startup warning

### DIFF
--- a/server/rest/submission.py
+++ b/server/rest/submission.py
@@ -33,6 +33,8 @@ from girder.utility import mail_utils
 
 class Submission(Resource):
     def __init__(self):
+        super(Submission, self).__init__()
+
         self.resourceName = 'covalic_submission'
 
         self.route('GET', (), self.listSubmissions)


### PR DESCRIPTION
This commit fixes the following warning when starting Girder:

    WARNING: Resource subclass "Submission" did not call "Resource__init__()" from its constructor.