### PR TITLE
Refs #37. Special handling of single-item dataset downloads

### DIFF
--- a/web_external/js/models/PhaseModel.js
+++ b/web_external/js/models/PhaseModel.js
@@ -13,6 +13,16 @@ covalic.models.PhaseModel = girder.AccessControlledModel.extend({
         }, this));
     },
 
+    fetchTestDataItems: function (params) {
+        var items = new girder.collections.ItemCollection();
+        items.altUrl = this.resourceName + '/' + this.get('_id') + '/test_data/item';
+        items.once('g:changed', function () {
+            this.trigger('c:testDataItemsFetched', items);
+        }, this).fetch(params);
+
+        return items;
+    },
+
     saveMetrics: function () {
         girder.restRequest({
             path: this.resourceName + '/' + this.get('_id') + '/metrics',

--- a/web_external/js/views/body/PhaseInputView.js
+++ b/web_external/js/views/body/PhaseInputView.js
@@ -87,7 +87,7 @@ covalic.views.PhaseInputView = covalic.View.extend({
     _uploadFinished: function (info) {
         this.uploadWidget.render();
         girder.events.trigger('g:alert', {
-            text: 'Added ' + info.files.length + ' ground truth files.',
+            text: 'Added ' + info.files.length + ' input files.',
             type: 'success',
             icon: 'ok',
             timeout: 4000

--- a/web_external/js/views/body/PhaseView.js
+++ b/web_external/js/views/body/PhaseView.js
@@ -113,8 +113,18 @@ covalic.views.PhaseView = covalic.View.extend({
                 _id: this.model.get('groundTruthFolderId')
             });
             gtFolder.once('g:fetched', function () {
-                this.$('.c-download-ground-truth').removeClass('hide')
-                    .attr('href', gtFolder.downloadUrl());
+                this.model.once('c:groundtruthItemsFetched', function (resp) {
+                    var downloadUrl;
+                    if (resp.length === 1) {
+                        downloadUrl = new girder.models.ItemModel({
+                            _id: resp[0]._id
+                        }).downloadUrl();
+                    } else {
+                        downloadUrl = gtFolder.downloadUrl();
+                    }
+                    this.$('.c-download-ground-truth').removeClass('hide')
+                        .attr('href', downloadUrl);
+                }, this).fetchGroundtruthItems();
             }, this).fetch({
                 ignoreError: true
             });
@@ -125,8 +135,16 @@ covalic.views.PhaseView = covalic.View.extend({
                 _id: this.model.get('testDataFolderId')
             });
             testFolder.once('g:fetched', function () {
-                this.$('.c-download-test-data').removeClass('hide')
-                    .attr('href', testFolder.downloadUrl());
+                this.model.once('c:testDataItemsFetched', function (coll) {
+                    var downloadUrl;
+                    if (coll.models.length === 1) {
+                        downloadUrl = coll.models[0].downloadUrl();
+                    } else {
+                        downloadUrl = testFolder.downloadUrl();
+                    }
+                    this.$('.c-download-test-data').removeClass('hide')
+                        .attr('href', downloadUrl);
+                }, this).fetchTestDataItems({limit: 2});
             }, this).fetch({
                 ignoreError: true
             });


### PR DESCRIPTION
For groundtruth or input folders of phases that contain only
a single item, we download just the item rather than the folder
containing it, to avoid an unnecessary zip file.

ping @brianhelba this is the fastest and simplest workaround I could come up with for your particular case. Hopefully it's good enough to also be the general solution.