### PR TITLE
Challenge timeline widget

### DIFF
--- a/web_external/js/.jshintrc
+++ b/web_external/js/.jshintrc
@@ -1,5 +1,6 @@
 {
     "predef"        : [         // Extra globals.
-        "covalic"
+        "covalic",
+        "moment"
     ]
 }

--- a/web_external/js/views/body/ChallengePhasesView.js
+++ b/web_external/js/views/body/ChallengePhasesView.js
@@ -17,7 +17,6 @@ covalic.views.ChallengePhasesView = covalic.View.extend({
     },
 
     initialize: function (settings) {
-        girder.cancelRestRequests('fetch');
         this.collection = new covalic.collections.ChallengePhaseCollection();
         this.collection.on('g:changed', function () {
             this.render();

--- a/web_external/js/views/body/ChallengeTimelineView.js
+++ b/web_external/js/views/body/ChallengeTimelineView.js
@@ -20,9 +20,12 @@ covalic.views.ChallengeTimelineView = covalic.View.extend({
         var tooltipFormat = 'dddd, D MMMM YYYY, h:mm:ss a';
 
         // Render timeline only when both start and end dates are specified
-        var startDate = moment(this.challenge.get('startDate'));
-        var endDate = moment(this.challenge.get('endDate'));
-        if (startDate.isValid() && endDate.isValid()) {
+        var startDateStr = this.challenge.get('startDate');
+        var endDateStr = this.challenge.get('endDate');
+        var startDate = !_.isEmpty(startDateStr) ? moment(startDateStr) : null;
+        var endDate = !_.isEmpty(endDateStr) ? moment(endDateStr) : null;
+        if (startDate && startDate.isValid() &&
+            endDate && endDate.isValid()) {
 
             // Add points at challenge start and end dates
             // May be hidden by phase points
@@ -41,10 +44,14 @@ covalic.views.ChallengeTimelineView = covalic.View.extend({
             // Add points at phase start and end dates
             var tooltip;
             _.each(this.collection.models, function (phase) {
-                var phaseStartDate = moment(phase.get('startDate'));
-                var phaseEndDate = moment(phase.get('endDate'));
+                var phaseStartDateStr = phase.get('startDate');
+                var phaseEndDateStr = phase.get('endDate');
+                var phaseStartDate = !_.isEmpty(phaseStartDateStr) ?
+                    moment(phaseStartDateStr) : null;
+                var phaseEndDate = !_.isEmpty(phaseEndDateStr) ?
+                    moment(phaseEndDateStr) : null;
 
-                if (phaseStartDate.isValid()) {
+                if (phaseStartDate && phaseStartDate.isValid()) {
                     point = this._createPoint(phaseStartDate, now);
                     tooltip = phase.get('name') + ' starts ';
                     tooltip += ' (' + phaseStartDate.format(tooltipFormat) + ')';
@@ -52,7 +59,7 @@ covalic.views.ChallengeTimelineView = covalic.View.extend({
                     points.push(point);
                 }
 
-                if (phaseEndDate.isValid()) {
+                if (phaseEndDate && phaseEndDate.isValid()) {
                     point = this._createPoint(phaseEndDate, now);
                     tooltip = phase.get('name') + ' ends ';
                     tooltip += ' (' + phaseEndDate.format(tooltipFormat) + ')';

--- a/web_external/js/views/body/ChallengeView.js
+++ b/web_external/js/views/body/ChallengeView.js
@@ -54,6 +54,11 @@ covalic.views.ChallengeView = covalic.View.extend({
     },
 
     _initWidgets: function () {
+        this.timelineView = new covalic.views.ChallengeTimelineView({
+            challenge: this.model,
+            parentView: this
+        });
+
         this.phasesView = new covalic.views.ChallengePhasesView({
             challenge: this.model,
             parentView: this
@@ -66,6 +71,8 @@ covalic.views.ChallengeView = covalic.View.extend({
             humanLink: '#challenge/n/' + encodeURIComponent(this.model.transformNameForUrl()),
             girder: girder
         }));
+
+        this.timelineView.setElement(this.$('.c-challenge-timeline-container')).render();
 
         girder.renderMarkdown(this.model.get('instructions') || '*No overview provided.*',
                               this.$('.c-challenge-instructions-container'));

--- a/web_external/stylesheets/body/challengePage.styl
+++ b/web_external/stylesheets/body/challengePage.styl
@@ -21,6 +21,9 @@
     color #444
     margin-top 6px
 
+.c-challenge-timeline-container
+  margin-top 5px
+
 .c-section-header
   color #7e8685
   font-size 25px

--- a/web_external/stylesheets/body/challengeTimelinePage.styl
+++ b/web_external/stylesheets/body/challengeTimelinePage.styl
@@ -1,0 +1,12 @@
+.c-challenge-timeline-segment-completed
+  background-color #44b2ce
+
+.c-challenge-timeline-segment-upcoming
+  background-color #ccc
+
+.c-challenge-timeline-point-completed
+  background-color #8cc1ce
+
+.c-challenge-timeline-point-upcoming
+  background-color #aaa
+

--- a/web_external/templates/body/challengePage.jade
+++ b/web_external/templates/body/challengePage.jade
@@ -27,6 +27,8 @@
   .c-challenge-organizers= challenge.get('organizers')
   .c-challenge-description= challenge.get('description')
 
+.c-challenge-timeline-container
+
 .c-overview-container
   .c-section-header
     | Overview


### PR DESCRIPTION
This is a first cut at adding a TimelineWidget to represent the schedule of a challenge:
![challenge_timeline](https://cloud.githubusercontent.com/assets/7122091/12271849/40389c88-b92b-11e5-947a-56c6378dba72.png)

Phase start/end dates appear as points. Details are in the tooltips.

Overall progress is represented using segments.