### PR TITLE
Challenge timeframe routing

### DIFF
--- a/web_external/js/views/body/ChallengesView.js
+++ b/web_external/js/views/body/ChallengesView.js
@@ -6,9 +6,9 @@ covalic.views.ChallengesView = covalic.View.extend({
     initialize: function () {
         girder.cancelRestRequests('fetch');
 
-        this.filter = 'all';
+        this.timeframe = 'all';
 
-        var params = { timeframe: this.filter };
+        var params = { timeframe: this.timeframe };
 
         this.collection = new covalic.collections.ChallengeCollection();
         this.collection.on('g:changed', function () {
@@ -40,7 +40,7 @@ covalic.views.ChallengesView = covalic.View.extend({
             challenges: this.collection.models,
             admin: !!(girder.currentUser && girder.currentUser.get('admin')),
             girder: girder,
-            filter: this.filter
+            timeframe: this.timeframe
         }));
 
         this.paginateWidget.setElement(this.$('.c-challenge-pagination')).render();
@@ -74,9 +74,9 @@ covalic.views.ChallengesView = covalic.View.extend({
 
     challengeFilterChanged: function (e) {
         var select = e.currentTarget;
-        this.filter = select.value;
+        this.timeframe = select.value;
 
-        var params = { timeframe: this.filter };
+        var params = { timeframe: this.timeframe };
         // FIXME fetch() ignores params when reset is true
         // Workaround: set params explicitly
         // this.collection.fetch(params, true);

--- a/web_external/js/views/body/ChallengesView.js
+++ b/web_external/js/views/body/ChallengesView.js
@@ -3,10 +3,10 @@ covalic.views.ChallengesView = covalic.View.extend({
         'change .c-challenges-filter': 'challengeFilterChanged'
     },
 
-    initialize: function () {
+    initialize: function (settings) {
         girder.cancelRestRequests('fetch');
 
-        this.timeframe = 'all';
+        this.timeframe = settings.timeframe || 'all';
 
         var params = { timeframe: this.timeframe };
 
@@ -75,6 +75,8 @@ covalic.views.ChallengesView = covalic.View.extend({
     challengeFilterChanged: function (e) {
         var select = e.currentTarget;
         this.timeframe = select.value;
+        covalic.router.navigate('challenges?timeframe=' + this.timeframe, {
+            replace: true});
 
         var params = { timeframe: this.timeframe };
         // FIXME fetch() ignores params when reset is true
@@ -85,6 +87,15 @@ covalic.views.ChallengesView = covalic.View.extend({
     }
 });
 
-covalic.router.route('challenges', 'challenges', function () {
-    girder.events.trigger('g:navigateTo', covalic.views.ChallengesView);
+covalic.router.route('challenges', 'challenges', function (params) {
+    params = girder.parseQueryString(params);
+
+    var timeframe = null;
+    if (_.has(params, 'timeframe')) {
+        timeframe = params.timeframe;
+    }
+
+    girder.events.trigger('g:navigateTo', covalic.views.ChallengesView, {
+        timeframe: timeframe
+    });
 });

--- a/web_external/templates/body/challengeList.jade
+++ b/web_external/templates/body/challengeList.jade
@@ -2,9 +2,9 @@
   form.c-challenge-search-form.form-inline(role="form")
     .form-group
       select.c-challenges-filter.form-control.input-sm
-        option(value="all" selected=(filter === 'all')) All challenges
-        option(value="active" selected=(filter === 'active')) Active challenges
-        option(value="upcoming" selected=(filter === 'upcoming')) Upcoming challenges
+        option(value="all" selected=(timeframe === 'all')) All challenges
+        option(value="active" selected=(timeframe === 'active')) Active challenges
+        option(value="upcoming" selected=(timeframe === 'upcoming')) Upcoming challenges
     .form-group.c-challenges-search-container
 
   if girder.currentUser


### PR DESCRIPTION
Previously if you selected a filter on the list of challenges, clicked through to a challenge, then went back in your browser, the filter would reset to the default. Now the selected filter is maintained through that workflow.