### PR TITLE
Distinguish training phases

### DIFF
--- a/web_external/js/views/body/NewPhaseView.js
+++ b/web_external/js/views/body/NewPhaseView.js
@@ -8,7 +8,8 @@ covalic.views.NewPhaseView = covalic.View.extend({
                 description: this.$('#c-challenge-description').val(),
                 active: this.$('#c-phase-active').is(':checked'),
                 startDate: this.dateTimeRangeWidget.fromDateString(),
-                endDate: this.dateTimeRangeWidget.toDateString()
+                endDate: this.dateTimeRangeWidget.toDateString(),
+                type: this.$('#c-phase-training').is(':checked') ? 'training' : ''
             });
 
             phase.on('g:saved', function () {

--- a/web_external/js/views/widgets/EditPhaseWidget.js
+++ b/web_external/js/views/widgets/EditPhaseWidget.js
@@ -11,7 +11,8 @@ covalic.views.EditPhaseWidget = covalic.View.extend({
                 description: this.$('#c-phase-description').val(),
                 active: this.$('#c-phase-active').is(':checked'),
                 startDate: this.dateTimeRangeWidget.fromDateString(),
-                endDate: this.dateTimeRangeWidget.toDateString()
+                endDate: this.dateTimeRangeWidget.toDateString(),
+                type: this.$('#c-phase-training').is(':checked') ? 'training' : ''
             };
 
             if (this.model) {
@@ -56,6 +57,11 @@ covalic.views.EditPhaseWidget = covalic.View.extend({
                     view.$('#c-phase-active').attr('checked', 'checked');
                 } else {
                     view.$('#c-phase-active').removeAttr('checked');
+                }
+                if (view.model.get('type') === 'training') {
+                    view.$('#c-phase-training').attr('checked', 'checked');
+                } else {
+                    view.$('#c-phase-training').removeAttr('checked');
                 }
 
                 view.dateTimeRangeWidget.setElement(view.$('#c-phase-timeframe')).render();

--- a/web_external/stylesheets/body/phasePage.styl
+++ b/web_external/stylesheets/body/phasePage.styl
@@ -12,6 +12,9 @@
   .c-phase-active
     float right
 
+  .c-phase-training
+    float right
+
   .c-phase-privacy
     overflow auto
 

--- a/web_external/templates/body/newPhasePage.jade
+++ b/web_external/templates/body/newPhasePage.jade
@@ -31,6 +31,10 @@ include ../mixins/wizardMixins
         label
           input#c-phase-active(type="checkbox")
           |  Active (accepting submissions)
+      .checkbox
+        label
+          input#c-phase-training(type="checkbox")
+          |  Training phase
     .g-validation-failed-message
 
   if wizard

--- a/web_external/templates/body/phasePage.jade
+++ b/web_external/templates/body/phasePage.jade
@@ -52,7 +52,10 @@
     if userInChallenge
         a.c-download-test-data.btn.btn-lg.btn-primary.hide
           i.icon-download
-          |  Download test dataset
+          if phase.get('type') === 'training'
+            |  Download training dataset
+          else
+            |  Download test dataset
         a.c-download-ground-truth.btn.btn-lg.btn-primary.hide
           i.icon-target
           |  Download ground truth data

--- a/web_external/templates/widgets/editPhaseWidget.jade
+++ b/web_external/templates/widgets/editPhaseWidget.jade
@@ -20,6 +20,10 @@
           label
             input#c-phase-active(type="checkbox")
             |  Active (accepting submissions)
+        .checkbox
+          label
+            input#c-phase-training(type="checkbox")
+            |  Training phase
         .g-validation-failed-message
       .modal-footer
         a.btn.btn-small.btn-default(data-dismiss="modal") Cancel


### PR DESCRIPTION
This adds an option to classify a phase as a 'training' phase. The user
interface is a simple checkbox ('Training phase').

Currently the only visible effect is to set the label of the button which
downloads the phase's dataset.

Depends on https://github.com/girder/challenge/pull/41

Fixes #150