### PR TITLE
Fix travis on python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
     - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "3" ]; then export PY3="true"; else export PY2="true"; fi
     - if [ -n "${PY3}" ]; then export IGNORE_PLUGINS=hdfs_assetstore,metadata_extractor; fi
     - cd "${HOME}"
+    - npm install -g npm
     - git clone git://github.com/girder/girder
     - curl "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.0.2.tgz" | gunzip -c | tar x
     - cd mongodb-*/bin && export PATH="${PWD}:${PATH}"


### PR DESCRIPTION
node-gyp requires python 2. Installing the latest version of
npm avoids this issue entirely.