### PR TITLE
Update stylesheet and script paths in web root

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -82,13 +82,12 @@ class CustomAppRoot(ModelImporter):
         <title>${title}</title>
         <link rel="stylesheet"
               href="//fonts.googleapis.com/css?family=Droid+Sans:400,700">
-        <link rel="stylesheet" href="${staticRoot}/built/bootstrap.min.css">
         <link rel="stylesheet"
-              href="${staticRoot}/lib/fontello/css/fontello.css">
+              href="${staticRoot}/built/fontello/css/fontello.css">
         <link rel="stylesheet"
-              href="${staticRoot}/lib/fontello/css/animation.css">
-        <link rel="stylesheet" href="${staticRoot}/built/ext.min.css">
-        <link rel="stylesheet" href="${staticRoot}/built/app.min.css">
+              href="${staticRoot}/built/fontello/css/animation.css">
+        <link rel="stylesheet" href="${staticRoot}/built/girder.ext.min.css">
+        <link rel="stylesheet" href="${staticRoot}/built/girder.app.min.css">
         <link rel="stylesheet"
               href="${staticRoot}/built/plugins/covalic/covalic.min.css">
         % for plugin in pluginCss:
@@ -103,8 +102,8 @@ class CustomAppRoot(ModelImporter):
       <body>
         <div id="g-global-info-apiroot" class="hide">${apiRoot}</div>
         <div id="g-global-info-staticroot" class="hide">${staticRoot}</div>
-        <script src="${staticRoot}/built/libs.min.js"></script>
-        <script src="${staticRoot}/built/app.min.js"></script>
+        <script src="${staticRoot}/built/girder.ext.min.js"></script>
+        <script src="${staticRoot}/built/girder.app.min.js"></script>
         % for plugin in pluginJs:
           <script src="${staticRoot}/built/plugins/${plugin}/plugin.min.js">
           </script>


### PR DESCRIPTION
This updates the references to Girder's libraries in the web root.

This fixes broken styling due to the reference to ext.min.css, which was
short-lived in the Girder repository and therefore doesn't have a compatibility
symlink.