### PR TITLE
Use phase match submissions field

### DIFF
--- a/web_external/js/views/body/NewPhaseView.js
+++ b/web_external/js/views/body/NewPhaseView.js
@@ -10,7 +10,8 @@ covalic.views.NewPhaseView = covalic.View.extend({
                 hideScores: this.$('#c-phase-hide-scores').is(':checked'),
                 startDate: this.dateTimeRangeWidget.fromDateString(),
                 endDate: this.dateTimeRangeWidget.toDateString(),
-                type: this.$('#c-phase-training').is(':checked') ? 'training' : ''
+                type: this.$('#c-phase-training').is(':checked') ? 'training' : '',
+                matchSubmissions: this.$('#c-phase-match-submissions').is(':checked')
             });
 
             phase.on('g:saved', function () {

--- a/web_external/js/views/body/SubmitView.js
+++ b/web_external/js/views/body/SubmitView.js
@@ -57,8 +57,14 @@ covalic.views.SubmitView = covalic.View.extend({
             _.map(this.phase.get('groundtruthItems'), transformName)
         );
 
-        matchInfo.ok = !(matchInfo.unmatchedGroundtruths.length ||
-                         matchInfo.unmatchedInputs.length);
+        var matchSubmissions = this.phase.get('matchSubmissions');
+        if (_.isUndefined(matchSubmissions)) {
+            matchSubmissions = true;
+        }
+
+        matchInfo.ok = !matchSubmissions ||
+                       (_.isEmpty(matchInfo.unmatchedGroundtruths) &&
+                        _.isEmpty(matchInfo.unmatchedInputs));
 
         var titleOk = this.$('input.c-submission-title-input').val().trim().length > 0;
 

--- a/web_external/js/views/widgets/EditPhaseWidget.js
+++ b/web_external/js/views/widgets/EditPhaseWidget.js
@@ -13,7 +13,8 @@ covalic.views.EditPhaseWidget = covalic.View.extend({
                 hideScores: this.$('#c-phase-hide-scores').is(':checked'),
                 startDate: this.dateTimeRangeWidget.fromDateString(),
                 endDate: this.dateTimeRangeWidget.toDateString(),
-                type: this.$('#c-phase-training').is(':checked') ? 'training' : ''
+                type: this.$('#c-phase-training').is(':checked') ? 'training' : '',
+                matchSubmissions: this.$('#c-phase-match-submissions').is(':checked')
             };
 
             if (this.model) {
@@ -68,6 +69,15 @@ covalic.views.EditPhaseWidget = covalic.View.extend({
                     view.$('#c-phase-hide-scores').attr('checked', 'checked');
                 } else {
                     view.$('#c-phase-hide-scores').removeAttr('checked');
+                }
+                var matchSubmissions = view.model.get('matchSubmissions');
+                if (_.isUndefined(matchSubmissions)) {
+                    matchSubmissions = true;
+                }
+                if (matchSubmissions) {
+                    view.$('#c-phase-match-submissions').attr('checked', 'checked');
+                } else {
+                    view.$('#c-phase-match-submissions').removeAttr('checked');
                 }
 
                 view.dateTimeRangeWidget.setElement(view.$('#c-phase-timeframe')).render();

--- a/web_external/stylesheets/body/phasePage.styl
+++ b/web_external/stylesheets/body/phasePage.styl
@@ -15,6 +15,9 @@
   .c-phase-training
     float right
 
+  .c-phase-match-submission
+    float right
+
   .c-phase-privacy
     overflow auto
 

--- a/web_external/templates/body/newPhasePage.jade
+++ b/web_external/templates/body/newPhasePage.jade
@@ -37,6 +37,10 @@ include ../mixins/wizardMixins
           |  Hide scores from participants
       .checkbox
         label
+          input#c-phase-match-submissions(type="checkbox", checked="checked")
+          |  Require submission filenames to match ground truth filenames
+      .checkbox
+        label
           input#c-phase-training(type="checkbox")
           |  Training phase
     .g-validation-failed-message

--- a/web_external/templates/body/submitPage.jade
+++ b/web_external/templates/body/submitPage.jade
@@ -1,11 +1,17 @@
+- var matchSubmissions = phase.get('matchSubmissions') === undefined || phase.get('matchSubmissions')
+
 .c-submit-page-title Submit to #{phase.get('name')}
 
 .c-submit-page-description
-  p.
-    To submit to this phase of the challenge, upload your output files here. The
-    output files must map one-to-one to each file from the input dataset. Your
-    files may have different file extensions, but otherwise the names should match
-    each corresponding input file.
+  if matchSubmissions
+    p.
+      To submit to this phase of the challenge, upload your output files here.
+      The output files must map one-to-one to each file from the input
+      dataset. Your files may have different file extensions, but otherwise
+      the names should match each corresponding input file.
+  else
+    p.
+      To submit to this phase of the challenge, upload your output files here.
   p.
     Before you upload your submission, please add a short title that identifies
     either your organization or your algorithm. This title doesn't have to be

--- a/web_external/templates/widgets/editPhaseWidget.jade
+++ b/web_external/templates/widgets/editPhaseWidget.jade
@@ -26,6 +26,10 @@
             |  Hide scores from participants
         .checkbox
           label
+            input#c-phase-match-submissions(type="checkbox")
+            |  Require submission filenames to match ground truth filenames
+        .checkbox
+          label
             input#c-phase-training(type="checkbox")
             |  Training phase
         .g-validation-failed-message


### PR DESCRIPTION
This commit adds user interface elements for and uses the phase match submission
field. When `matchSubmissions` is true, submission filenames must match ground
truth filenames one-to-one. When `matchSubmissions` is false, any filenames are
accepted.

Depends on https://github.com/girder/challenge/pull/45