### PR TITLE
Include error logs in email

### DIFF
--- a/server/constants.py
+++ b/server/constants.py
@@ -18,5 +18,9 @@
 ###############################################################################
 
 
+# Prefix for Covalic-specific error messages in job log.
+JOB_LOG_PREFIX = 'covalic.error:'
+
+
 class PluginSettings():
     SCORING_USER_ID = 'covalic.scoring_user_id'

--- a/server/mail_templates/covalic.submissionCompleteAdmin.mako
+++ b/server/mail_templates/covalic.submissionCompleteAdmin.mako
@@ -6,7 +6,8 @@ A submission has been scored successfully.
 
 <p>
 A submission to the challenge <b>${challenge['name']} (${phase['name']})</b>
-from <b>${user['firstName']} ${user['lastName']}</b> (${user['email']})
+from user <b>${user['login']}</b>
+(<b><a href="mailto:${user['email']}">${user['firstName']} ${user['lastName']}</a></b>)
 named <b>${submission['title']}</b> has finished processing.
 You can view the results
 <a href="${host}#submission/${submission['_id']}">here</a>.

--- a/server/mail_templates/covalic.submissionErrorAdmin.mako
+++ b/server/mail_templates/covalic.submissionErrorAdmin.mako
@@ -1,8 +1,30 @@
 <%include file="_header.mako"/>
 
 <p>
-An error occurred while scoring the submission
-<a href="${host}/#submission/${submissionId}">${submissionId}</a>.
+An error occurred while scoring the submission named
+<b>${submission['title']}</b>
+to the challenge
+<b>${challenge['name']} (${phase['name']})</b>
+from user <b>${user['login']}</b>
+(<b><a href="mailto:${user['email']}">${user['firstName']} ${user['lastName']}</a></b>):
+</p>
+
+% if log:
+<p>
+Log output:
+</p>
+<pre>
+${log}
+</pre>
+% else:
+<p>
+No log is available.
+</p>
+% endif
+
+<p>
+You can also view these results
+<a href="${host}#submission/${submission['_id']}">here</a>.
 </p>
 
 <p>

--- a/server/mail_templates/covalic.submissionErrorUser.mako
+++ b/server/mail_templates/covalic.submissionErrorUser.mako
@@ -1,12 +1,24 @@
 <%include file="_header.mako"/>
 
 <p>
-An error occurred while scoring the submission
-<a href="${host}/#submission/${submissionId}">${submissionId}</a>.
+An error occurred while scoring your submission named
+<b>${submission['title']}</b>
+to the challenge
+<b>${challenge['name']} (${phase['name']})</b>:
 </p>
 
+% if log:
+<pre>
+${log}
+</pre>
+% else:
 <p>
-Please check your submission and try again.
+No log is available.
+</p>
+% endif
+
+<p>
+Please fix the error and try again.
 </p>
 
 <%include file="_footer.mako"/>


### PR DESCRIPTION
Include error logs when sending email notifications of a submission error. The
admin email includes the full error log and the user email includes a minimal
error log. The minimal error log contains the specific error from the scoring
container to help the user fix their submission.

Additionally, the admin email template for a successful submission is updated
for consistency with the error template with respect to the included user
information.

Fixes #168