### PR TITLE
Allow score metric values to be null

### DIFF
--- a/server/scoring.py
+++ b/server/scoring.py
@@ -18,6 +18,7 @@
 ###############################################################################
 
 from collections import defaultdict
+import six
 
 
 def computeAverageScores(score):
@@ -25,18 +26,27 @@ def computeAverageScores(score):
     Compute the average score for each metric and add it to the score list
     under the name "Average".
 
+    Datasets with a score of None are omitted from the average calculation.
+
     :param score: The score object to compute the average of. The result of the
         computation is placed at the head of the list.
     :type score: list
     """
     sums = defaultdict(float)
+    counts = defaultdict(int)
 
     for dataset in score:
         for metric in dataset['metrics']:
-            sums[metric['name']] += float(metric['value'])
+            if metric['value'] is not None:
+                sums[metric['name']] += float(metric['value'])
+                counts[metric['name']] += 1
 
-    n = float(len(score))
-    metrics = [{'name': k, 'value': s / n} for k, s in sums.iteritems()]
+    metrics = [
+        {
+            'name': metricName,
+            'value': sums[metricName] / float(counts[metricName])
+        }
+        for metricName in sorted(six.viewkeys())]
 
     score.insert(0, {
         'dataset': 'Average',

--- a/server/scoring.py
+++ b/server/scoring.py
@@ -46,7 +46,7 @@ def computeAverageScores(score):
             'name': metricName,
             'value': sums[metricName] / float(counts[metricName])
         }
-        for metricName in sorted(six.viewkeys())]
+        for metricName in sorted(six.viewkeys(sums))]
 
     score.insert(0, {
         'dataset': 'Average',

--- a/web_external/js/views/widgets/ScoreDetailWidget.js
+++ b/web_external/js/views/widgets/ScoreDetailWidget.js
@@ -56,6 +56,9 @@ covalic.views.ScoreDetailWidget = covalic.View.extend({
             return true;
         });
 
+        if (score === null) {
+            return '';
+        }
         if (score < 0.0001) {
             return Number(score).toExponential(2);
         } else {


### PR DESCRIPTION
This permits a sparse scoring matrix to be created, where the missing values do not affect the average score for a given metric type.