### PR TITLE
Hide leaderboard references when hiding scores

### DIFF
--- a/web_external/js/views/body/PhaseView.js
+++ b/web_external/js/views/body/PhaseView.js
@@ -178,6 +178,8 @@ covalic.views.PhaseView = covalic.View.extend({
                 el: this.$('.c-leaderboard-widget-container'),
                 parentView: this
             }).render();
+        } else {
+            this.$('.c-leaderboard-outer-wrapper').hide();
         }
 
         this.$('button[title]').tooltip({

--- a/web_external/templates/body/submissionPage.jade
+++ b/web_external/templates/body/submissionPage.jade
@@ -1,8 +1,11 @@
 .c-submission-header-bar
   .c-submission-right-buttons.pull-right
     a.c-leaderboard-button(href="#phase/#{submission.get('phaseId')}")
-      |  View leaderboard&nbsp;
-      i.icon-right-big
+      if scoreHidden
+        |  Return to phase&nbsp;
+      else
+        |  View leaderboard&nbsp;
+        i.icon-right-big
 
   .c-header-info-wrapper
     .c-user-portrait


### PR DESCRIPTION
When hiding scores:
- Hide 'Leaderboard' header on phase page
- Replace 'View leaderboard' text on button that returns to phase after submitting

Fixes #175 