### PR TITLE
Fix sorting by overall score on leaderboard

### DIFF
--- a/web_external/js/collections/SubmissionCollection.js
+++ b/web_external/js/collections/SubmissionCollection.js
@@ -2,5 +2,8 @@ covalic.collections.SubmissionCollection = girder.Collection.extend({
     resourceName: 'covalic_submission',
     model: covalic.models.SubmissionModel,
 
+    sortField: 'overallScore',
+    sortDir: girder.SORT_DESC,
+
     pageLimit: 100
 });


### PR DESCRIPTION
This overrides the default `girder.Collection` sort options for a
`SubmissionCollection`. By default, a `girder.Collection` is sorted by the 'name'
parameter, which does not exist for submissions.