### PR TITLE
Allow site admins to submit on behalf of users

### DIFF
--- a/server/models/submission.py
+++ b/server/models/submission.py
@@ -21,6 +21,7 @@ import datetime
 
 from girder.constants import AccessType
 from girder.models.model_base import Model
+from girder.plugins.challenge.models.utility import validateDate
 from girder.plugins.covalic import scoring
 from girder.utility.progress import noProgress
 
@@ -40,6 +41,9 @@ class Submission(Model):
         ))
 
     def validate(self, doc):
+        if doc.get('created'):
+            doc['created'] = validateDate(doc.get('created'), 'created')
+
         if doc.get('score') is not None and doc.get('overallScore') is None:
             scoring.computeAverageScores(doc['score'])
             phase = self.model('phase', 'challenge').load(
@@ -104,13 +108,14 @@ class Submission(Model):
         for result in cursor:
             yield result
 
-    def createSubmission(self, creator, phase, folder, job=None, title=None):
+    def createSubmission(self, creator, phase, folder, job=None, title=None,
+                         created=None):
         submission = {
             'creatorId': creator['_id'],
             'creatorName': creator['firstName'] + ' ' + creator['lastName'],
             'phaseId': phase['_id'],
             'folderId': folder['_id'],
-            'created': datetime.datetime.utcnow(),
+            'created': created or datetime.datetime.utcnow(),
             'score': None,
             'title': title
         }

--- a/server/rest/submission.py
+++ b/server/rest/submission.py
@@ -134,16 +134,14 @@ class Submission(Resource):
         # Site admins may override the submission creation date
         created = None
         if 'date' in params:
-            if not user.get('admin'):
-                raise ValidationException('You may not override the '
-                                          'submission creation date.')
+            self.requireAdmin(user, 'Administrator access required to override '
+                                    'the submission creation date.')
             created = params['date']
 
         # Site admins may submit on behalf of another user
         if 'userId' in params:
-            if not user.get('admin'):
-                raise ValidationException('You may not submit to this phase '
-                                          'on behalf of another user.')
+            self.requireAdmin(user, 'Administrator access required to submit '
+                                    'to this phase on behalf of another user.')
             user = self.model('user').load(params['userId'], force=True,
                                            exc=True)
 


### PR DESCRIPTION
The POST submission endpoint now accepts two optional parameters, both of which
require site admin access:
- date: override the submission creation date.
- userId: the user to submit on behalf of.

This enables admins to add a user's submission to the system when the user was
unable to do so themselves.