### PR TITLE
Exclude score field when listing all submissions

### DIFF
--- a/server/models/submission.py
+++ b/server/models/submission.py
@@ -96,7 +96,8 @@ class Submission(Model):
 
         Model.remove(self, doc, progress=progress)
 
-    def list(self, phase, limit=50, offset=0, sort=None, userFilter=None):
+    def list(self, phase, limit=50, offset=0, sort=None, userFilter=None,
+             fields=None):
         q = {'phaseId': phase['_id']}
 
         if userFilter is not None:
@@ -104,7 +105,8 @@ class Submission(Model):
         else:
             q['latest'] = True
 
-        cursor = self.find(q, limit=limit, offset=offset, sort=sort)
+        cursor = self.find(q, limit=limit, offset=offset, sort=sort,
+                           fields=fields)
         for result in cursor:
             yield result
 

--- a/server/rest/submission.py
+++ b/server/rest/submission.py
@@ -96,8 +96,12 @@ class Submission(Resource):
             userFilter = self.model('user').load(
                 params['userId'], user=user, level=AccessType.READ)
 
+        # Exclude score field
+        fields = {'score': False}
+
         submissions = self.model('submission', 'covalic').list(
-            phase, limit=limit, offset=offset, sort=sort, userFilter=userFilter)
+            phase, limit=limit, offset=offset, sort=sort, userFilter=userFilter,
+            fields=fields)
         return [self._filterScore(phase, s, user) for s in submissions]
 
     @access.user


### PR DESCRIPTION
Exclude the score field from submissions when listing all submissions. This
change makes listing submissions more scalable with a large number of
submissions or many score metrics.

The score field remains accessible when requesting a submission directly by its
ID.