### PR TITLE
Keep mongo database on its own volume

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -9,3 +9,4 @@ mongo_hosts: "{{ groups.get('tag_type_mongodb', ['localhost']) | intersect(pod_h
 mq_hosts: "{{ groups.get('tag_type_mq', ['localhost']) | intersect(pod_hosts) }}"
 mq_private_ip: "{{ hostvars[mq_hosts[0]].get('ec2_private_ip_address', 'localhost') }}"
 mongo_private_ip: "{{ hostvars[mongo_hosts[0]].get('ec2_private_ip_address', 'localhost') }}"
+mongo_dbpath: /mongodata

--- a/ansible/roles/mongodb/tasks/main.yml
+++ b/ansible/roles/mongodb/tasks/main.yml
@@ -46,6 +46,16 @@
     - mongodb
     - rewire
 
+- name: Make mongo use the larger EBS volume for the database
+  sudo: yes
+  lineinfile:
+    dest: /etc/mongod.conf
+    state: present
+    regexp: 'dbpath=(.*)'
+    line: "dbpath={{ mongo_dbpath }}"
+  tags:
+    - mongodb
+
 - name: Run mongo daemon
   sudo: yes
   service: name=mongod state=restarted

--- a/ansible/usage.md
+++ b/ansible/usage.md
@@ -123,8 +123,7 @@ The scripts in the `utils` dir make use of encrypted variable files like
 
 ## Backing up the production database
 
-To create a backup of the production database, SSH into the database machine and
-export your `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. Then, run:
+To create a backup of the production database, SSH into the database machine and run:
 
     ~/backup_db.sh
 

--- a/ansible/vagrant.yml
+++ b/ansible/vagrant.yml
@@ -26,3 +26,4 @@
     girder_assetstore_local_fs: true
     worker_exec_user: vagrant
     worker_exec_group: vagrant
+    mongo_dbpath: /vagrant/mongodata


### PR DESCRIPTION
This coincides with changing the mongodb prod instance to a
more powerful machine with a much larger volume. The new
machine is also under a special IAM role so that it does not
require credentials to write into the backup bucket.

ping @mgrauer 