### PR TITLE
Use href for phase links

### DIFF
--- a/web_external/js/views/body/ChallengePhasesView.js
+++ b/web_external/js/views/body/ChallengePhasesView.js
@@ -1,9 +1,5 @@
 covalic.views.ChallengePhasesView = covalic.View.extend({
     events: {
-        'click a.c-phase-link': function (event) {
-            var cid = $(event.currentTarget).attr('c-phase-cid');
-            covalic.router.navigate('phase/' + this.collection.get(cid).id, {trigger: true});
-        },
         'c:update-phase-ordinals .c-phase-list': function (event) {
             var collection = this.collection;
             $('li a.c-phase-link', $(event.currentTarget)).each(function (ordinal) {

--- a/web_external/templates/body/challengePhasesPage.jade
+++ b/web_external/templates/body/challengePhasesPage.jade
@@ -8,7 +8,7 @@ ul.c-phase-list
   each phase in phases
     li.c-phase-list-entry
       .c-challenge-phase-header
-      a.c-phase-link(c-phase-cid="#{phase.cid}")
+      a.c-phase-link(c-phase-cid="#{phase.cid}" href="#phase/#{phase.get('_id')}")
         i.icon-clock
         | #{phase.get('name')}
       i.c-phase-reorder.icon-menu(title="Drag to re-order")

--- a/web_external/templates/body/challengePhasesPage.jade
+++ b/web_external/templates/body/challengePhasesPage.jade
@@ -8,7 +8,7 @@ ul.c-phase-list
   each phase in phases
     li.c-phase-list-entry
       .c-challenge-phase-header
-      a.c-phase-link(c-phase-cid="#{phase.cid}" href="#phase/#{phase.get('_id')}")
+      a.c-phase-link(c-phase-cid=phase.cid href="#phase/#{phase.id}")
         i.icon-clock
         | #{phase.get('name')}
       i.c-phase-reorder.icon-menu(title="Drag to re-order")


### PR DESCRIPTION
Previously, links to phases on the challenge page used an event handler that
calls router.navigate().

Now, links to phases use an href. This allows actions like opening phases in new
tabs and copying the link URL.