### PR TITLE
Add basic submission dashboard

### DIFF
--- a/web_external/js/models/SubmissionModel.js
+++ b/web_external/js/models/SubmissionModel.js
@@ -16,5 +16,9 @@ covalic.models.SubmissionModel = girder.Model.extend({
         }, this)).error(_.bind(function (err) {
             this.trigger('c:error', err);
         }, this));
+    },
+
+    downloadUrl: function () {
+        return girder.apiRoot + '/folder/' + this.get('folderId') + '/download';
     }
 });

--- a/web_external/js/views/body/PhaseSubmissionsView.js
+++ b/web_external/js/views/body/PhaseSubmissionsView.js
@@ -59,7 +59,7 @@ covalic.views.PhaseSubmissionsView = covalic.View.extend({
 covalic.router.route('phase/:id/submissions', 'phaseSubmissions', function (id, params) {
     var phase = new covalic.models.PhaseModel({
         _id: id
-    }).on('g:fetched', function () {
+    }).once('g:fetched', function () {
         if (phase.getAccessLevel() < girder.AccessType.WRITE) {
             covalic.router.navigate('challenges', {trigger: true});
         } else {

--- a/web_external/js/views/body/PhaseSubmissionsView.js
+++ b/web_external/js/views/body/PhaseSubmissionsView.js
@@ -1,0 +1,86 @@
+/**
+* View for submissions to a phase.
+*/
+covalic.views.PhaseSubmissionsView = covalic.View.extend({
+    initialize: function (settings) {
+        girder.cancelRestRequests('fetch');
+
+        var participantLimit = 5;
+        if (!_.isNull(settings.participantLimit)) {
+            participantLimit = Math.max(1, parseInt(settings.participantLimit, 10));
+        }
+
+        this.views = [];
+
+        if (settings.phase) {
+            this.phase = settings.phase;
+
+            this.participants = new girder.collections.UserCollection();
+            this.participants.altUrl =
+                'group/' + this.phase.get('participantGroupId') + '/member';
+            this.participants.pageLimit = participantLimit;
+            this.participants.on('g:changed', function () {
+                this.views = [];
+                this.participants.each(_.bind(function (user) {
+                    this.views.push(new covalic.views.UserSubmissionsView({
+                        phase: this.phase,
+                        user: user,
+                        submissionLimit: settings.submissionLimit,
+                        parentView: this
+                    }));
+                }, this));
+                this.render();
+            }, this).fetch();
+
+            this.paginateWidget = new girder.views.PaginateWidget({
+                collection: this.participants,
+                parentView: this
+            });
+        }
+    },
+
+    render: function () {
+        this.$el.html(covalic.templates.phaseSubmissionsPage({
+            phase: this.phase
+        }));
+
+        var container = $('.c-user-submissions-container');
+
+        _.each(this.views, function (view) {
+            container.append(view.render().el);
+        });
+
+        this.paginateWidget.setElement(this.$('.c-phase-participants-pagination')).render();
+
+        return this;
+    }
+});
+
+covalic.router.route('phase/:id/submissions', 'phaseSubmissions', function (id, params) {
+    var phase = new covalic.models.PhaseModel({
+        _id: id
+    }).on('g:fetched', function () {
+        if (phase.getAccessLevel() < girder.AccessType.WRITE) {
+            covalic.router.navigate('challenges', {trigger: true});
+        } else {
+            params = girder.parseQueryString(params);
+
+            var participantLimit = null;
+            var submissionLimit = null;
+            if (_.has(params, 'participantLimit')) {
+                participantLimit = params.participantLimit;
+            }
+            if (_.has(params, 'submissionLimit')) {
+                submissionLimit = params.submissionLimit;
+            }
+
+            girder.events.trigger('g:navigateTo', covalic.views.PhaseSubmissionsView, {
+                phase: phase,
+                participantLimit: participantLimit,
+                submissionLimit: submissionLimit
+            });
+        }
+    }, this).on('g:error', function () {
+        covalic.router.navigate('challenges', {trigger: true});
+    }, this).fetch();
+});

--- a/web_external/js/views/body/UserSubmissionsView.js
+++ b/web_external/js/views/body/UserSubmissionsView.js
@@ -1,0 +1,90 @@
+/**
+* View for a user's submissions to a phase.
+*/
+covalic.views.UserSubmissionsView = covalic.View.extend({
+    initialize: function (settings) {
+        this.phase = settings.phase;
+        this.user = settings.user;
+
+        var submissionLimit = 5;
+        if (!_.isNull(settings.submissionLimit)) {
+            submissionLimit = Math.max(1, parseInt(settings.submissionLimit, 10));
+        }
+
+        new girder.views.LoadingAnimation({
+            el: this.$el,
+            parentView: this
+        }).render();
+
+        // XXX: add way to get total number of submissions without fetching all
+        this.submissions = new covalic.collections.SubmissionCollection();
+        this.submissions.sortField = 'created';
+        this.submissions.sortDir = girder.SORT_DESC;
+        this.submissions.pageLimit = submissionLimit;
+        this.submissions.on('g:changed', function () {
+            // Assume submissions that have overallScore were successful.
+            // Fetch jobs for all other submissions.
+            var unscoredSubmissions =
+                _.filter(this.submissions.models, function (submission) {
+                    return _.isUndefined(submission.get('overallScore'));
+                });
+            if (unscoredSubmissions.length > 0) {
+                var jobs = [];
+                var promises = [];
+                _.each(unscoredSubmissions, function (submission) {
+                    var deferred = $.Deferred();
+                    var job = new girder.models.JobModel({
+                        _id: submission.get('jobId')
+                    }).on('g:fetched', function () {
+                        deferred.resolve();
+                    }, this).on('g:error', function () {
+                        deferred.reject();
+                    }, this).fetch();
+                    jobs.push(job);
+                    promises.push(deferred.promise());
+                });
+                $.when.apply($, promises).done(_.bind(function () {
+                    var jobMap = _.indexBy(jobs, 'id');
+                    this.render({jobs: jobMap});
+                }, this));
+            } else {
+                this.render();
+            }
+        }, this).fetch({
+            phaseId: this.phase.id,
+            userId: this.user.id
+        });
+
+        this.paginateWidget = new girder.views.PaginateWidget({
+            collection: this.submissions,
+            parentView: this
+        });
+    },
+
+    render: function (params) {
+        this.$el.html(covalic.templates.userSubmissionsPage({
+            user: this.user,
+            submissions: this.submissions,
+            girder: girder,
+            moment: moment,
+            jobs: params && params.jobs
+        }));
+
+        this.paginateWidget.setElement(this.$('.c-user-submissions-pagination')).render();
+
+        var tooltipParams = {
+            container: this.$el,
+            animation: false,
+            delay: {show: 100}
+        };
+
+        this.$('.c-tooltip').tooltip(tooltipParams);
+
+        // Override tooltip template to set custom inner class
+        this.$('.c-job-log-tooltip').tooltip(_.extend(tooltipParams, {
+            template: '<div class="tooltip" role="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner c-job-log-tooltip-inner"></div></div>'
+        }));
+
+        return this;
+    }
+});

--- a/web_external/js/views/body/UserSubmissionsView.js
+++ b/web_external/js/views/body/UserSubmissionsView.js
@@ -17,7 +17,7 @@ covalic.views.UserSubmissionsView = covalic.View.extend({
 
         var submissionLimit = 5;
         if (!_.isNull(settings.submissionLimit)) {
-            submissionLimit = Math.max(1, parseInt(settings.submissionLimit, 10));
+            submissionLimit = Math.max(1, window.parseInt(settings.submissionLimit, 10));
         }
 
         new girder.views.LoadingAnimation({

--- a/web_external/js/views/body/UserSubmissionsView.js
+++ b/web_external/js/views/body/UserSubmissionsView.js
@@ -65,6 +65,7 @@ covalic.views.UserSubmissionsView = covalic.View.extend({
         this.$el.html(covalic.templates.userSubmissionsPage({
             user: this.user,
             submissions: this.submissions,
+            getShortLog: this._getShortLog,
             girder: girder,
             moment: moment,
             jobs: params && params.jobs
@@ -86,5 +87,18 @@ covalic.views.UserSubmissionsView = covalic.View.extend({
         }));
 
         return this;
+    },
+
+    /**
+     * Return a string that contains the first numLines lines of a job's log.
+     * The string ends in an ellipsis if any lines were omitted.
+     */
+    _getShortLog: function (job, numLines) {
+        var logLines = job.get('log').split('\n');
+        var shortLog = logLines.slice(0, numLines);
+        if (logLines.length > numLines && numLines > 0) {
+            shortLog.push('...');
+        }
+        return shortLog.join('\n');
     }
 });

--- a/web_external/js/views/body/UserSubmissionsView.js
+++ b/web_external/js/views/body/UserSubmissionsView.js
@@ -2,6 +2,15 @@
 * View for a user's submissions to a phase.
 */
 covalic.views.UserSubmissionsView = covalic.View.extend({
+    events: {
+        'click a.c-submission-json-link': function (event) {
+            var submissionId = $(event.currentTarget).attr('c-submission-id');
+            var submission = this.submissions.get(submissionId);
+            var submissionJson = JSON.stringify(submission, null, 4);
+            console.info(submissionJson);
+        }
+    },
+
     initialize: function (settings) {
         this.phase = settings.phase;
         this.user = settings.user;

--- a/web_external/stylesheets/body/phaseSubmissionsPage.styl
+++ b/web_external/stylesheets/body/phaseSubmissionsPage.styl
@@ -1,0 +1,13 @@
+@import 'nib'
+
+.c-phase-submissions-title
+  font-weight bold
+  font-size 20px
+
+.c-phase-participants-pagination
+
+  .pagination
+    user-select none
+
+  .pagination>li>a
+    padding 7px 30px

--- a/web_external/stylesheets/body/userSubmissionsPage.styl
+++ b/web_external/stylesheets/body/userSubmissionsPage.styl
@@ -1,0 +1,68 @@
+@import 'nib'
+
+.c-user-submissions-panel
+
+  .c-user-submissions-user-info
+    background-color #ffffff
+    font-size 16px
+    cursor default
+
+    .c-user-name
+      font-size larger
+
+    .c-user-login
+    .c-user-email
+      color #aaa
+      padding-left 1em
+
+    .c-user-submissions-pagination
+      >ul
+        margin 0
+
+      .pagination
+        user-select none
+
+      .pagination>li>a
+        float none
+        line-height 1.5
+        padding 3px 12px
+
+.c-user-submissions-table
+  width 100%
+
+  thead>tr,th
+    font-weight normal
+
+  tbody>tr
+    &:nth-child(odd)>td
+    &:nth-child(odd)>th
+      background-color #f2f2f2
+
+  tbody
+    .c-submission-title
+      width 25%
+    .c-submission-status
+      width 10%
+    .c-submission-date
+      width 30%
+    .c-submission-score
+      width 10%
+    .c-submission-download>a
+    .c-submission-raw>a
+      color #777
+
+.c-job-log-tooltip-inner
+  white-space pre
+  max-width none
+  text-align left
+
+.c-user-submissions-footer
+  padding 5px 15px
+  font-size 12px
+  color #aaa
+  background-color #fff
+
+.c-no-submit
+.c-no-success
+  font-size 14px
+

--- a/web_external/stylesheets/body/userSubmissionsPage.styl
+++ b/web_external/stylesheets/body/userSubmissionsPage.styl
@@ -48,7 +48,7 @@
     .c-submission-score
       width 10%
     .c-submission-download>a
-    .c-submission-raw>a
+    .c-submission-json>a
       color #777
 
 .c-job-log-tooltip-inner

--- a/web_external/templates/body/phasePage.jade
+++ b/web_external/templates/body/phasePage.jade
@@ -75,3 +75,7 @@
 .c-leaderboard-outer-wrapper
   .c-section-header Leaderboard
   .c-leaderboard-widget-container
+
+  if phase.getAccessLevel() >= girder.AccessType.WRITE
+    a.btn.btn-default.btn-sm(href="#phase/#{phase.id}/submissions")
+      | View all submissions

--- a/web_external/templates/body/phaseSubmissionsPage.jade
+++ b/web_external/templates/body/phaseSubmissionsPage.jade
@@ -1,0 +1,8 @@
+.c-phase-submissions-title
+  a(href="#phase/#{phase.id}")= phase.get('name')
+  i.icon-angle-right
+  | All Submissions
+
+.c-phase-participants-pagination
+
+.c-user-submissions-container

--- a/web_external/templates/body/userSubmissionsPage.jade
+++ b/web_external/templates/body/userSubmissionsPage.jade
@@ -1,6 +1,7 @@
 - var hasSubmissions = submissions.length > 0
 - var hasSuccessfulSubmission = false
 - var endOfSubmissions = !submissions.hasNextPage()
+- var successText = girder.jobs_JobStatus.text(girder.jobs_JobStatus.SUCCESS)
 
 .c-user-submissions-panel.panel.panel-default
   .c-user-submissions-user-info.panel-heading.clearfix
@@ -35,18 +36,18 @@
               if submission.get('latest')
                 i.icon-ok
             td.c-submission-status
-              a(href="#job/#{submission.get('jobId')}")
                 if hasScore
-                  = girder.jobs_JobStatus.text(girder.jobs_JobStatus.SUCCESS)
                   - hasSuccessfulSubmission = true
+                  if siteAdmin
+                    a(href="#job/#{submission.get('jobId')}")= successText
+                  else
+                    = successText
                 else
                   - var job = jobs !== undefined && jobs[submission.get('jobId')]
                   if job
-                    span.c-job-log-tooltip(
+                    a(href="#job/#{submission.get('jobId')}").c-job-log-tooltip(
                       title=getShortLog(job, 5))
                        = girder.jobs_JobStatus.text(job.get('status'))
-                  else
-                    | --
             td.c-submission-date= dateStr
             td.c-submission-score
               if hasScore

--- a/web_external/templates/body/userSubmissionsPage.jade
+++ b/web_external/templates/body/userSubmissionsPage.jade
@@ -1,0 +1,90 @@
+- var hasSubmissions = submissions.length > 0
+- var hasSuccessfulSubmission = false
+- var endOfSubmissions = !submissions.hasNextPage()
+
+- function getShortLog(job, numLines) {
+-   var logLines = job.get('log').split('\n')
+-   var shortLog = logLines.slice(0, numLines)
+-   if (logLines.length > numLines && numLines > 0) {
+-     shortLog.push('...')
+-   }
+-   return shortLog.join('\n')
+-  }
+
+.c-user-submissions-panel.panel.panel-default
+  .c-user-submissions-user-info.panel-heading.clearfix
+    - var fullName = user.get('firstName') + ' ' + user.get('lastName')
+    - var login = user.get('login')
+    - var email = user.get('email')
+    span.c-user-name= fullName
+    a.c-user-login(href="#user/#{user.id}")= login
+    a.c-user-email(href="mailto:#{email}")= email
+    span.c-user-submissions-pagination.pull-right
+
+  if hasSubmissions
+    table.table.table-striped.table-condensed.c-user-submissions-table
+      thead
+        tr
+          th Title
+          th Latest
+          th Status
+          th Date
+          th Score
+          th
+          th
+      tbody
+        each submission in submissions.models
+          - var hasScore = submission.get('overallScore') !== undefined
+          - var date = moment(submission.get('created'))
+          - var dateStr = date.format('ddd, D MMM YYYY, h:mm:ss a')
+          - var downloadUrl = girder.apiRoot + '/folder/' + submission.get('folderId') + '/download'
+          - var rawUrl = girder.apiRoot + '/covalic_submission/' + submission.id
+          tr
+            td.c-submission-title= submission.get('title') || '--'
+            td.c-submission-latest
+              if submission.get('latest')
+                i.icon-ok
+            td.c-submission-status
+              a(href="#job/#{submission.get('jobId')}")
+                if hasScore
+                  // 3: Success
+                  - var jobStatus = 3
+                  = girder.jobs_JobStatus.text(jobStatus)
+                  - hasSuccessfulSubmission = true
+                else
+                  - var job = jobs !== undefined && jobs[submission.get('jobId')]
+                  if job
+                    - var jobStatus = job.get('status')
+                    span.c-job-log-tooltip(
+                      title="#{getShortLog(job, 5)}")
+                       = girder.jobs_JobStatus.text(jobStatus)
+                  else
+                    | --
+            td.c-submission-date= dateStr
+            td.c-submission-score
+              if hasScore
+                a.c-score-link(
+                    href="#submission/#{submission.id}")= (Math.round(submission.get('overallScore') * 1000) / 1000).toFixed(3)
+            td.c-submission-download
+              a.c-tooltip(
+                title="Download submission data"
+                href="#{downloadUrl}")
+                  | download
+            td.c-submission-raw
+              a.c-tooltip(
+                title="View raw submission JSON"
+                href="#{rawUrl}")
+                  | view raw
+
+  if !hasSubmissions || !hasSuccessfulSubmission || (hasSubmissions && endOfSubmissions)
+    .c-user-submissions-footer.panel-footer
+      if !hasSubmissions
+        .c-no-submit.text-warning
+          i.icon-attention
+          |  No submissions
+      else if !hasSuccessfulSubmission
+        .c-no-success.text-danger
+          i.icon-cancel
+          |  No successful submissions on this page
+      if hasSubmissions && endOfSubmissions
+          | &ndash; end of submissions &ndash;

--- a/web_external/templates/body/userSubmissionsPage.jade
+++ b/web_external/templates/body/userSubmissionsPage.jade
@@ -2,15 +2,6 @@
 - var hasSuccessfulSubmission = false
 - var endOfSubmissions = !submissions.hasNextPage()
 
-- function getShortLog(job, numLines) {
--   var logLines = job.get('log').split('\n')
--   var shortLog = logLines.slice(0, numLines)
--   if (logLines.length > numLines && numLines > 0) {
--     shortLog.push('...')
--   }
--   return shortLog.join('\n')
--  }
-
 .c-user-submissions-panel.panel.panel-default
   .c-user-submissions-user-info.panel-heading.clearfix
     - var fullName = user.get('firstName') + ' ' + user.get('lastName')

--- a/web_external/templates/body/userSubmissionsPage.jade
+++ b/web_external/templates/body/userSubmissionsPage.jade
@@ -4,12 +4,12 @@
 
 .c-user-submissions-panel.panel.panel-default
   .c-user-submissions-user-info.panel-heading.clearfix
-    - var fullName = user.get('firstName') + ' ' + user.get('lastName')
-    - var login = user.get('login')
-    - var email = user.get('email')
-    span.c-user-name= fullName
-    a.c-user-login(href="#user/#{user.id}")= login
-    a.c-user-email(href="mailto:#{email}")= email
+    i.icon-user
+    span.c-user-name= user.name()
+    a.c-user-login(href="#user/#{user.id}")= user.get('login')
+    if user.has('email')
+      - var email = user.get('email')
+      a.c-user-email(href="mailto:#{email}")= email
     span.c-user-submissions-pagination.pull-right
 
   if hasSubmissions
@@ -25,10 +25,9 @@
           th
       tbody
         each submission in submissions.models
-          - var hasScore = submission.get('overallScore') !== undefined
+          - var hasScore = submission.has('overallScore')
           - var date = moment(submission.get('created'))
           - var dateStr = date.format('ddd, D MMM YYYY, h:mm:ss a')
-          - var downloadUrl = girder.apiRoot + '/folder/' + submission.get('folderId') + '/download'
           - var rawUrl = girder.apiRoot + '/covalic_submission/' + submission.id
           tr
             td.c-submission-title= submission.get('title') || '--'
@@ -38,17 +37,14 @@
             td.c-submission-status
               a(href="#job/#{submission.get('jobId')}")
                 if hasScore
-                  // 3: Success
-                  - var jobStatus = 3
-                  = girder.jobs_JobStatus.text(jobStatus)
+                  = girder.jobs_JobStatus.text(girder.jobs_JobStatus.SUCCESS)
                   - hasSuccessfulSubmission = true
                 else
                   - var job = jobs !== undefined && jobs[submission.get('jobId')]
                   if job
-                    - var jobStatus = job.get('status')
                     span.c-job-log-tooltip(
-                      title="#{getShortLog(job, 5)}")
-                       = girder.jobs_JobStatus.text(jobStatus)
+                      title=getShortLog(job, 5))
+                       = girder.jobs_JobStatus.text(job.get('status'))
                   else
                     | --
             td.c-submission-date= dateStr
@@ -58,13 +54,13 @@
                     href="#submission/#{submission.id}")= (Math.round(submission.get('overallScore') * 1000) / 1000).toFixed(3)
             td.c-submission-download
               a.c-tooltip(
-                title="Download submission data"
-                href="#{downloadUrl}")
+                title="Download submission data",
+                href=submission.downloadUrl())
                   | download
             td.c-submission-raw
               a.c-tooltip(
-                title="View raw submission JSON"
-                href="#{rawUrl}")
+                title="View raw submission JSON",
+                href=rawUrl)
                   | view raw
 
   if !hasSubmissions || !hasSuccessfulSubmission || (hasSubmissions && endOfSubmissions)

--- a/web_external/templates/body/userSubmissionsPage.jade
+++ b/web_external/templates/body/userSubmissionsPage.jade
@@ -29,7 +29,6 @@
           - var hasScore = submission.has('overallScore')
           - var date = moment(submission.get('created'))
           - var dateStr = date.format('ddd, D MMM YYYY, h:mm:ss a')
-          - var rawUrl = girder.apiRoot + '/covalic_submission/' + submission.id
           tr
             td.c-submission-title= submission.get('title') || '--'
             td.c-submission-latest
@@ -58,11 +57,11 @@
                 title="Download submission data",
                 href=submission.downloadUrl())
                   | download
-            td.c-submission-raw
-              a.c-tooltip(
-                title="View raw submission JSON",
-                href=rawUrl)
-                  | view raw
+            td.c-submission-json
+              a.c-submission-json-link.c-tooltip(
+                title="Dump submission JSON to console"
+                c-submission-id="#{submission.id}")
+                  | dump json
 
   if !hasSubmissions || !hasSuccessfulSubmission || (hasSubmissions && endOfSubmissions)
     .c-user-submissions-footer.panel-footer


### PR DESCRIPTION
This adds an administrator interface to view all submissions to a phase. A
button at the bottom of the phase page routes to this interface.

Currently, the view shows submissions grouped by participant. By default,
submissions for up to five participants are shown at a time. The controls at the
top of the interface page through the list. The 'participantLimit' query
parameter sets the number of participants per page.

By default, up to five submissions per participant are shown at a time. The
controls in the group for each user page through the list. The 'submissionLimit'
query parameter sets the number of submissions to show per page.

Each submission shows its title, whether it's the latest successful submission,
its job status, its creation date, and its overall score. The job status text
links to the job detail page. Unsuccessful jobs include a tooltip showing the
first few lines of the job log. The overall score text links to the score detail
page. Links are provided to download the submission data and to view the raw
submission JSON.

To provide some extra information, warning messages are shown when a user hasn't
submitted at all or when the current page shows no successful submissions.

Some useful extensions, perhaps requiring backend enhancements to be efficient,
to this could include:
- display success/error/total submission counts per user/phase/challenge
- identify and group participants who have no successful submissions
- identify and group participants who haven't submitted
- filtering/sorting tables

Fixes #186 

![all_submissions](https://cloud.githubusercontent.com/assets/7122091/15058255/35a7eb62-12e9-11e6-94d8-6d44cc64b484.png)