### PR TITLE
Allow phase admins to read submission folders

### DIFF
--- a/plugin.cmake
+++ b/plugin.cmake
@@ -1,5 +1,6 @@
 add_python_test(user_emails PLUGIN covalic)
 add_python_test(asset_folder PLUGIN covalic)
+add_python_test(submission_folder_access PLUGIN covalic)
 add_python_style_test(python_static_analysis_covalic
                       "${PROJECT_SOURCE_DIR}/plugins/covalic/server")
 

--- a/plugin_tests/submission_folder_access_test.py
+++ b/plugin_tests/submission_folder_access_test.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+from tests import base
+from girder.constants import AccessType
+
+
+def setUpModule():
+    base.enabledPlugins.append('covalic')
+    base.startServer()
+
+
+def tearDownModule():
+    base.stopServer()
+
+
+class SubmissionFolderAccessTestCase(base.TestCase):
+    def testSubmissionFolderAccess(self):
+        # Create users
+        challengeAdmin = self.model('user').createUser(
+            email='challenge@email.com', login='challenge',
+            firstName='Challenge', lastName='Admin', password='passwd')
+        phaseAdmin1 = self.model('user').createUser(
+            email='phase1@email.com', login='phase1',
+            firstName='Phase', lastName='Admin 1', password='passwd')
+        phaseAdmin2 = self.model('user').createUser(
+            email='phase2@email.com', login='phase2',
+            firstName='Phase', lastName='Admin 2', password='passwd')
+        user1 = self.model('user').createUser(
+            email='user1@email.com', login='user1',
+            firstName='User', lastName='1', password='passwd')
+
+        challengeModel = self.model('challenge', 'challenge')
+        phaseModel = self.model('phase', 'challenge')
+        folderModel = self.model('folder')
+        submissionModel = self.model('submission', 'covalic')
+
+        # Create challenge and phase
+        challenge = challengeModel.createChallenge(
+            name='challenge 1', creator=challengeAdmin, public=False)
+        phase = phaseModel.createPhase(
+            name='phase 1', challenge=challenge, creator=phaseAdmin1, ordinal=1)
+
+        # Add phaseAdmin2 and user 1 as phase admins
+        phaseModel.setUserAccess(phase, phaseAdmin2, AccessType.WRITE, save=True)
+        phaseModel.setUserAccess(phase, user1, AccessType.WRITE, save=True)
+
+        # Create folder and submission as user1
+        submissionFolder = folderModel.createFolder(
+            parent=user1, name='submission 1', parentType='user', creator=user1)
+        submissionModel.createSubmission(
+            creator=user1, phase=phase, folder=submissionFolder)
+
+        # Submission folder ACL should include phase admins with read access
+        submissionFolder = folderModel.load(
+            submissionFolder['_id'], force=True, exc=True)
+        self.assertEqual(len(submissionFolder['access']['users']), 3)
+        self.assertEqual(submissionFolder['access']['users'][0]['id'],
+                         user1['_id'])
+        self.assertEqual(submissionFolder['access']['users'][0]['level'],
+                         AccessType.ADMIN)
+        self.assertEqual(submissionFolder['access']['users'][1]['id'],
+                         phaseAdmin1['_id'])
+        self.assertEqual(submissionFolder['access']['users'][1]['level'],
+                         AccessType.READ)
+        self.assertEqual(submissionFolder['access']['users'][2]['id'],
+                         phaseAdmin2['_id'])
+        self.assertEqual(submissionFolder['access']['users'][2]['level'],
+                         AccessType.READ)
+
+        # Remove user1 as phase admin. This shouldn't change folder ACL because
+        # user1 is the folder's owner.
+        phaseModel.setUserAccess(phase, user1, None, save=True)
+        submissionFolder = folderModel.load(
+            submissionFolder['_id'], force=True, exc=True)
+        self.assertEqual(len(submissionFolder['access']['users']), 3)
+        self.assertEqual(submissionFolder['access']['users'][0]['id'],
+                         user1['_id'])
+        self.assertEqual(submissionFolder['access']['users'][0]['level'],
+                         AccessType.ADMIN)
+        self.assertEqual(submissionFolder['access']['users'][1]['id'],
+                         phaseAdmin1['_id'])
+        self.assertEqual(submissionFolder['access']['users'][1]['level'],
+                         AccessType.READ)
+        self.assertEqual(submissionFolder['access']['users'][2]['id'],
+                         phaseAdmin2['_id'])
+        self.assertEqual(submissionFolder['access']['users'][2]['level'],
+                         AccessType.READ)
+
+        # Remove phaseAdmin2 as a phase admin. This should remove phaseAdmin2
+        # from the submission folder ACL.
+        phaseModel.setUserAccess(phase, phaseAdmin2, None, save=True)
+        submissionFolder = folderModel.load(
+            submissionFolder['_id'], force=True, exc=True)
+        self.assertEqual(len(submissionFolder['access']['users']), 2)
+        self.assertEqual(submissionFolder['access']['users'][0]['id'],
+                         user1['_id'])
+        self.assertEqual(submissionFolder['access']['users'][0]['level'],
+                         AccessType.ADMIN)
+        self.assertEqual(submissionFolder['access']['users'][1]['id'],
+                         phaseAdmin1['_id'])
+        self.assertEqual(submissionFolder['access']['users'][1]['level'],
+                         AccessType.READ)
+
+        # Re-add phaseAdmin2 as phase admin. This should add phaseAdmin2 back to
+        # the submission folder ACL.
+        phaseModel.setUserAccess(phase, phaseAdmin2, AccessType.WRITE, save=True)
+        submissionFolder = folderModel.load(
+            submissionFolder['_id'], force=True, exc=True)
+        self.assertEqual(len(submissionFolder['access']['users']), 3)
+        self.assertEqual(submissionFolder['access']['users'][0]['id'],
+                         user1['_id'])
+        self.assertEqual(submissionFolder['access']['users'][0]['level'],
+                         AccessType.ADMIN)
+        self.assertEqual(submissionFolder['access']['users'][1]['id'],
+                         phaseAdmin1['_id'])
+        self.assertEqual(submissionFolder['access']['users'][1]['level'],
+                         AccessType.READ)
+        self.assertEqual(submissionFolder['access']['users'][2]['id'],
+                         phaseAdmin2['_id'])
+        self.assertEqual(submissionFolder['access']['users'][2]['level'],
+                         AccessType.READ)
+
+        # Change phaseAdmin2's access to read-only. This should remove
+        # phaseAdmin2 from the submission folder ACL.
+        phaseModel.setUserAccess(phase, phaseAdmin2, AccessType.READ, save=True)
+        submissionFolder = folderModel.load(
+            submissionFolder['_id'], force=True, exc=True)
+        self.assertEqual(len(submissionFolder['access']['users']), 2)
+        self.assertEqual(submissionFolder['access']['users'][0]['id'],
+                         user1['_id'])
+        self.assertEqual(submissionFolder['access']['users'][0]['level'],
+                         AccessType.ADMIN)
+        self.assertEqual(submissionFolder['access']['users'][1]['id'],
+                         phaseAdmin1['_id'])
+        self.assertEqual(submissionFolder['access']['users'][1]['level'],
+                         AccessType.READ)
+
+        # Verify that the phase can be modified and saved successfully if a
+        # submission folder has been deleted
+        folderModel.remove(submissionFolder)
+        phaseModel.setUserAccess(phase, phaseAdmin1, None, save=True)

--- a/plugin_tests/submission_folder_access_test.py
+++ b/plugin_tests/submission_folder_access_test.py
@@ -17,6 +17,8 @@
 #  limitations under the License.
 ###############################################################################
 
+import six
+
 from tests import base
 from girder.constants import AccessType
 
@@ -31,6 +33,21 @@ def tearDownModule():
 
 
 class SubmissionFolderAccessTestCase(base.TestCase):
+    @staticmethod
+    def _filterUserAccessKeys(folder):
+        """
+        Filter a folder's user access control list to contain only keys relevant
+        for this test. In certain workflows,
+        AccessControlledModel.getFullAccessList() adds additional keys such as
+        'login' and 'name'. Removing the additional keys simplifies writing
+        equality assertions.
+        """
+        for item in folder['access']['users']:
+            toDelete = [key for key in six.viewkeys(item)
+                        if key not in ('id', 'level')]
+            for key in toDelete:
+                del item[key]
+
     def testSubmissionFolderAccess(self):
         # Create users
         challengeAdmin = self.model('user').createUser(
@@ -71,18 +88,21 @@ class SubmissionFolderAccessTestCase(base.TestCase):
         submissionFolder = folderModel.load(
             submissionFolder['_id'], force=True, exc=True)
         self.assertEqual(len(submissionFolder['access']['users']), 3)
-        self.assertEqual(submissionFolder['access']['users'][0]['id'],
-                         user1['_id'])
-        self.assertEqual(submissionFolder['access']['users'][0]['level'],
-                         AccessType.ADMIN)
-        self.assertEqual(submissionFolder['access']['users'][1]['id'],
-                         phaseAdmin1['_id'])
-        self.assertEqual(submissionFolder['access']['users'][1]['level'],
-                         AccessType.READ)
-        self.assertEqual(submissionFolder['access']['users'][2]['id'],
-                         phaseAdmin2['_id'])
-        self.assertEqual(submissionFolder['access']['users'][2]['level'],
-                         AccessType.READ)
+        self._filterUserAccessKeys(submissionFolder)
+        six.assertCountEqual(self, submissionFolder['access']['users'], [
+            {
+                'id': user1['_id'],
+                'level': AccessType.ADMIN
+            },
+            {
+                'id': phaseAdmin1['_id'],
+                'level': AccessType.READ
+            },
+            {
+                'id': phaseAdmin2['_id'],
+                'level': AccessType.READ
+            }
+        ])
 
         # Remove user1 as phase admin. This shouldn't change folder ACL because
         # user1 is the folder's owner.
@@ -90,18 +110,21 @@ class SubmissionFolderAccessTestCase(base.TestCase):
         submissionFolder = folderModel.load(
             submissionFolder['_id'], force=True, exc=True)
         self.assertEqual(len(submissionFolder['access']['users']), 3)
-        self.assertEqual(submissionFolder['access']['users'][0]['id'],
-                         user1['_id'])
-        self.assertEqual(submissionFolder['access']['users'][0]['level'],
-                         AccessType.ADMIN)
-        self.assertEqual(submissionFolder['access']['users'][1]['id'],
-                         phaseAdmin1['_id'])
-        self.assertEqual(submissionFolder['access']['users'][1]['level'],
-                         AccessType.READ)
-        self.assertEqual(submissionFolder['access']['users'][2]['id'],
-                         phaseAdmin2['_id'])
-        self.assertEqual(submissionFolder['access']['users'][2]['level'],
-                         AccessType.READ)
+        self._filterUserAccessKeys(submissionFolder)
+        six.assertCountEqual(self, submissionFolder['access']['users'], [
+            {
+                'id': user1['_id'],
+                'level': AccessType.ADMIN
+            },
+            {
+                'id': phaseAdmin1['_id'],
+                'level': AccessType.READ
+            },
+            {
+                'id': phaseAdmin2['_id'],
+                'level': AccessType.READ
+            }
+        ])
 
         # Remove phaseAdmin2 as a phase admin. This should remove phaseAdmin2
         # from the submission folder ACL.
@@ -109,14 +132,17 @@ class SubmissionFolderAccessTestCase(base.TestCase):
         submissionFolder = folderModel.load(
             submissionFolder['_id'], force=True, exc=True)
         self.assertEqual(len(submissionFolder['access']['users']), 2)
-        self.assertEqual(submissionFolder['access']['users'][0]['id'],
-                         user1['_id'])
-        self.assertEqual(submissionFolder['access']['users'][0]['level'],
-                         AccessType.ADMIN)
-        self.assertEqual(submissionFolder['access']['users'][1]['id'],
-                         phaseAdmin1['_id'])
-        self.assertEqual(submissionFolder['access']['users'][1]['level'],
-                         AccessType.READ)
+        self._filterUserAccessKeys(submissionFolder)
+        six.assertCountEqual(self, submissionFolder['access']['users'], [
+            {
+                'id': user1['_id'],
+                'level': AccessType.ADMIN
+            },
+            {
+                'id': phaseAdmin1['_id'],
+                'level': AccessType.READ
+            }
+        ])
 
         # Re-add phaseAdmin2 as phase admin. This should add phaseAdmin2 back to
         # the submission folder ACL.
@@ -124,18 +150,21 @@ class SubmissionFolderAccessTestCase(base.TestCase):
         submissionFolder = folderModel.load(
             submissionFolder['_id'], force=True, exc=True)
         self.assertEqual(len(submissionFolder['access']['users']), 3)
-        self.assertEqual(submissionFolder['access']['users'][0]['id'],
-                         user1['_id'])
-        self.assertEqual(submissionFolder['access']['users'][0]['level'],
-                         AccessType.ADMIN)
-        self.assertEqual(submissionFolder['access']['users'][1]['id'],
-                         phaseAdmin1['_id'])
-        self.assertEqual(submissionFolder['access']['users'][1]['level'],
-                         AccessType.READ)
-        self.assertEqual(submissionFolder['access']['users'][2]['id'],
-                         phaseAdmin2['_id'])
-        self.assertEqual(submissionFolder['access']['users'][2]['level'],
-                         AccessType.READ)
+        self._filterUserAccessKeys(submissionFolder)
+        six.assertCountEqual(self, submissionFolder['access']['users'], [
+            {
+                'id': user1['_id'],
+                'level': AccessType.ADMIN
+            },
+            {
+                'id': phaseAdmin1['_id'],
+                'level': AccessType.READ
+            },
+            {
+                'id': phaseAdmin2['_id'],
+                'level': AccessType.READ
+            }
+        ])
 
         # Change phaseAdmin2's access to read-only. This should remove
         # phaseAdmin2 from the submission folder ACL.
@@ -143,14 +172,17 @@ class SubmissionFolderAccessTestCase(base.TestCase):
         submissionFolder = folderModel.load(
             submissionFolder['_id'], force=True, exc=True)
         self.assertEqual(len(submissionFolder['access']['users']), 2)
-        self.assertEqual(submissionFolder['access']['users'][0]['id'],
-                         user1['_id'])
-        self.assertEqual(submissionFolder['access']['users'][0]['level'],
-                         AccessType.ADMIN)
-        self.assertEqual(submissionFolder['access']['users'][1]['id'],
-                         phaseAdmin1['_id'])
-        self.assertEqual(submissionFolder['access']['users'][1]['level'],
-                         AccessType.READ)
+        self._filterUserAccessKeys(submissionFolder)
+        six.assertCountEqual(self, submissionFolder['access']['users'], [
+            {
+                'id': user1['_id'],
+                'level': AccessType.ADMIN
+            },
+            {
+                'id': phaseAdmin1['_id'],
+                'level': AccessType.READ
+            }
+        ])
 
         # Verify that the phase can be modified and saved successfully if a
         # submission folder has been deleted

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -167,6 +167,79 @@ def challengeSaved(event):
         challenge, folder, save=True)
 
 
+def onSubmissionCreated(event):
+    """
+    Hook into submission created event to set up access control on the
+    submission folder. Phase admins should have read access.
+    """
+    submission = event.info
+
+    folderModel = ModelImporter.model('folder')
+    userModel = ModelImporter.model('user')
+    phaseModel = ModelImporter.model('phase', 'challenge')
+
+    # Get phase admin user ids
+    folder = folderModel.load(submission['folderId'], force=True, exc=True)
+    phase = phaseModel.load(submission['phaseId'], force=True, exc=True)
+    phaseAcl = phaseModel.getFullAccessList(phase)
+    phaseAdminUsers = [userModel.load(user['id'], force=True, exc=True)
+                       for user in phaseAcl.get('users')
+                       if (user['level'] >= AccessType.WRITE and
+                           user['id'] != folder['creatorId'])]
+
+    # Update phase submission folder ACL for phase admins
+    for user in phaseAdminUsers:
+        folderModel.setUserAccess(folder, user, AccessType.READ)
+    if phaseAdminUsers:
+        folderModel.save(folder, validate=False)
+
+
+def onPhaseSave(event):
+    """
+    Hook into phase save event to synchronize access control between the phase
+    and submission folders for the phase. Phase admins should have read access
+    on the submission folders.
+    """
+    phase = event.info
+
+    folderModel = ModelImporter.model('folder')
+    userModel = ModelImporter.model('user')
+    phaseModel = ModelImporter.model('phase', 'challenge')
+    submissionModel = ModelImporter.model('submission', 'covalic')
+
+    # Get phase admin users
+    phaseAcl = phaseModel.getFullAccessList(phase)
+    phaseAdminUserIds = [user['id']
+                         for user in phaseAcl.get('users')
+                         if user['level'] >= AccessType.WRITE]
+    phaseAdminUsers = [userModel.load(userId, force=True, exc=True)
+                       for userId in phaseAdminUserIds]
+
+    # Update phase submission folder ACL for current phase admins
+    submissions = submissionModel.getAllSubmissions(phase)
+    for sub in submissions:
+        folder = folderModel.load(sub['folderId'], force=True)
+        if not folder:
+            continue
+        folderAcl = folderModel.getFullAccessList(folder)
+
+        # Revoke access to users who are not phase admins
+        usersToRemove = [userModel.load(user['id'], force=True, exc=True)
+                         for user in folderAcl.get('users')
+                         if (user['id'] not in phaseAdminUserIds and
+                             user['id'] != folder['creatorId'])]
+        for user in usersToRemove:
+            folderModel.setUserAccess(folder, user, None)
+
+        # Add access to phase admins
+        for user in phaseAdminUsers:
+            folderModel.setUserAccess(folder, user, AccessType.READ)
+
+        # Save folder if access changed
+        if usersToRemove or phaseAdminUsers:
+            folderModel.save(folder, validate=False)
+
+
 def onJobUpdate(event):
     """
     Hook into job update event so we can look for job failure events and email
@@ -261,6 +334,10 @@ def load(info):
     events.bind('model.challenge_phase.validate', 'covalic', validatePhase)
     events.bind('model.challenge_challenge.save.after', 'covalic',
                 challengeSaved)
+    events.bind('model.covalic_submission.save.created', 'covalic',
+                onSubmissionCreated)
+    events.bind('model.challenge_phase.save.after', 'covalic',
+                onPhaseSave)
     events.bind('model.user.save.after', 'covalic', onUserSave)
 
     # Expose extended fields on models


### PR DESCRIPTION
Phase admins are granted read permission on submission folders.

Submission folder permissions are updated if a phase's access control changes.

Fixes #195 