### PR TITLE
Allow downloading submission data

### DIFF
--- a/web_external/stylesheets/body/submissionPage.styl
+++ b/web_external/stylesheets/body/submissionPage.styl
@@ -14,6 +14,9 @@
   padding-bottom 10px
   margin-bottom 10px
 
+.c-submission-download-container
+  margin 10px 0px
+
 .c-submission-overall-score-container
   background-color #d6f0b4
   padding 15px

--- a/web_external/templates/body/submissionPage.jade
+++ b/web_external/templates/body/submissionPage.jade
@@ -15,6 +15,11 @@
       .c-submission-subtitle Submitted #[b= created] by #[b= submission.get('creatorName')]
 
 .c-submission-display-body
+  if download
+    .c-submission-download-container
+      a.c-download-submission-data.btn.btn-lg.btn-primary
+        i.icon-download
+        |  Download submission
   if submission.has('overallScore')
     .c-submission-overall-score-container
       .c-pre-text Overall score:


### PR DESCRIPTION
This commit adds a button on the submission detail page to download the
submission data. The button is visible to phase admins. If a submission folder
contains only one item, then the item is downloaded directly. Otherwise, the
folder is downloaded as a zip file.

Fixes #198