### PR TITLE
On submission dashboard, add link to submission

### DIFF
--- a/web_external/templates/body/userSubmissionsPage.jade
+++ b/web_external/templates/body/userSubmissionsPage.jade
@@ -30,7 +30,8 @@
           - var date = moment(submission.get('created'))
           - var dateStr = date.format('ddd, D MMM YYYY, h:mm:ss a')
           tr
-            td.c-submission-title= submission.get('title') || '--'
+            td.c-submission-title
+              a(href="#submission/#{submission.id}")= submission.get('title') || '--'
             td.c-submission-latest
               if submission.get('latest')
                 i.icon-ok


### PR DESCRIPTION
This commit adds a direct link back to the submission view. When a submission is
successful, this provides a shortcut to view the score details without
navigating back to the leaderboard. When a submission fails, this makes it
easier to restart the submission from the submission view.

Fixes #201 