### PR TITLE
Display phase descriptions on challenge overview page

### DIFF
--- a/web_external/js/views/body/NewChallengeView.js
+++ b/web_external/js/views/body/NewChallengeView.js
@@ -16,11 +16,9 @@ covalic.views.NewChallengeView = covalic.View.extend({
                     this.wizard.total, {trigger: true});
             }, this).off('g:error').on('g:error', function (err) {
                 this.$('.g-validation-failed-message').text(err.responseJSON.message);
-                this.$('button.c-save-challenge').removeClass('disabled');
                 this.$('#c-challenge-' + err.responseJSON.field).focus();
             }, this).save();
 
-            this.$('button.c-save-challenge').addClass('disabled');
             this.$('.g-validation-failed-message').text('');
         }
     },

--- a/web_external/js/views/body/NewPhaseView.js
+++ b/web_external/js/views/body/NewPhaseView.js
@@ -5,7 +5,7 @@ covalic.views.NewPhaseView = covalic.View.extend({
             phase.set({
                 challengeId: this.challenge.id,
                 name: this.$('#c-phase-name').val(),
-                description: this.$('#c-challenge-description').val(),
+                description: this.$('#c-phase-description').val(),
                 active: this.$('#c-phase-active').is(':checked'),
                 hideScores: this.$('#c-phase-hide-scores').is(':checked'),
                 startDate: this.dateTimeRangeWidget.fromDateString(),

--- a/web_external/js/views/body/NewPhaseView.js
+++ b/web_external/js/views/body/NewPhaseView.js
@@ -20,11 +20,9 @@ covalic.views.NewPhaseView = covalic.View.extend({
                     this.wizard.total, {trigger: true});
             }, this).off('g:error').on('g:error', function (err) {
                 this.$('.g-validation-failed-message').text(err.responseJSON.message);
-                this.$('button.c-save-challenge').removeClass('disabled');
                 this.$('#c-phase-' + err.responseJSON.field).focus();
             }, this).save();
 
-            this.$('button.c-save-challenge').addClass('disabled');
             this.$('.g-validation-failed-message').text('');
         }
     },

--- a/web_external/stylesheets/body/challengePage.styl
+++ b/web_external/stylesheets/body/challengePage.styl
@@ -62,6 +62,7 @@
       font-size 16px
       background-color #f6f6f6
       border 1px solid #e6e6e6
+      display flex
 
       .c-phase-reorder
         float right
@@ -71,6 +72,17 @@
     &>li.sortable-placeholder
       border 1px dashed #CCC
       background none
+
+    .c-phase-icon
+      padding-right 4px
+      color #666
+
+    .c-phase-text
+      flex 1
+
+      .c-phase-description
+        font-weight normal
+        color #666
 
 .c-phase-create
   @extend .c-challenge-create-button

--- a/web_external/templates/body/challengePhasesPage.jade
+++ b/web_external/templates/body/challengePhasesPage.jade
@@ -7,10 +7,12 @@
 ul.c-phase-list
   each phase in phases
     li.c-phase-list-entry
-      .c-challenge-phase-header
-      a.c-phase-link(c-phase-cid=phase.cid href="#phase/#{phase.id}")
-        i.icon-clock
-        | #{phase.get('name')}
+      i.c-phase-icon.icon-clock
+      .c-phase-text
+        .c-phase-name
+          a.c-phase-link(c-phase-cid=phase.cid href="#phase/#{phase.id}")
+            = phase.get('name')
+        .c-phase-description= phase.get('description')
       i.c-phase-reorder.icon-menu(title="Drag to re-order")
 
 if !phases.length


### PR DESCRIPTION
cc: @brianhelba 

Screenshot:
![image](https://cloud.githubusercontent.com/assets/7122091/21065948/ec8ab36c-be30-11e6-8bd9-f860c5aa4561.png)

Currently this displays the description in its entirety. We had discussed truncating it, but I'm not sure that's necessary.

Fixes #209 