### PR TITLE
Fix job log emails

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -157,9 +157,14 @@ def onJobUpdate(event):
 
         # Create minimal log that contains only Covalic errors.
         # Use full log if no Covalic-specific errors are found.
-        log = event.info['job'].get('log')
+        # Fetch log from model, because log in event may not be up-to-date.
+        job = ModelImporter.model('job', 'jobs').load(
+            event.info['job']['_id'], includeLog=True, force=True)
+        log = job.get('log')
+
         minimalLog = None
         if log:
+            log = ''.join(log)
             minimalLog = '\n'.join([line[len(JOB_LOG_PREFIX):].strip()
                                     for line in log.splitlines()
                                     if line.startswith(JOB_LOG_PREFIX)])


### PR DESCRIPTION
Fix a problem where the job log emails don't include the submission job
log. The emails erroneously stated that "No log is available."

The first problem is that the log sent in the `jobs.job.update` event is
no longer necessarily up-to-date, and may be empty. According to the
documentation [1], the job document should be manually re-refetched to
get the complete log.

The second problem is that the log is now a list, and the list elements
aren't necessarily broken at newlines. To fix this, we join the list
into a string before processing it.

[1] http://girder.readthedocs.io/en/latest/plugins.html