### PR TITLE
Fix phase page menu item spacing

### DIFF
--- a/web_external/templates/body/phasePage.pug
+++ b/web_external/templates/body/phasePage.pug
@@ -17,11 +17,11 @@
                         li(role="presentation")
                           a.c-ground-truth(href=`#phase/${phase.id}/groundtruth`, role="menuitem")
                             i.icon-target
-                            | Ground truth dataset...
+                            |  Ground truth dataset...
                         li(role="presentation")
                           a.c-test-data(href=`#phase/${phase.id}/input`, role="menuitem")
                             i.icon-beaker
-                            | Input dataset...
+                            |  Input dataset...
                         li(role="presentation")
                             a.c-edit-metrics(role="menuitem", href=`#phase/${phase.id}/metrics`)
                               i.icon-chart-bar
@@ -35,7 +35,7 @@
                             li(role="presentation")
                               a(href=`#phase/${phase.id}/access`, role="menuitem")
                                 i.icon-lock
-                                | Access control
+                                |  Access control
                             li(role="presentation")
                               a.c-delete-phase(role="menuitem") #[i.icon-trash] Delete phase
 


### PR DESCRIPTION
Fix a regression where several items on the phase page menu are misaligned. This first regressed in https://github.com/girder/covalic/commit/e28bed2ac9b6da0818699408c4e7c855e048c38f.