### PR TITLE
Add optional submission fields

### DIFF
--- a/plugin_tests/phase_test.py
+++ b/plugin_tests/phase_test.py
@@ -187,7 +187,10 @@ class PhaseTestCase(base.TestCase):
             endDate='2015-12-01T14:00:00.000Z',
             type='type',
             hideScores=True,
-            matchSubmissions=False)
+            matchSubmissions=False,
+            enableOrganization=True,
+            enableOrganizationUrl=True,
+            enableDocumentationUrl=True)
 
         resp = self.request(path='/challenge_phase/%s' % phase['_id'],
                             user=self.user)
@@ -209,6 +212,9 @@ class PhaseTestCase(base.TestCase):
         self.assertEqual(resp.json['type'], 'type')
         self.assertTrue(resp.json['hideScores'])
         self.assertFalse(resp.json['matchSubmissions'])
+        self.assertTrue(resp.json['enableOrganization'])
+        self.assertTrue(resp.json['enableOrganizationUrl'])
+        self.assertTrue(resp.json['enableDocumentationUrl'])
 
     def testGetPhaseInvalid(self):
         resp = self.request(path='/challenge_phase/1', user=self.user)
@@ -227,7 +233,10 @@ class PhaseTestCase(base.TestCase):
             endDate='2015-12-01T14:00:00.000Z',
             type='type',
             hideScores=True,
-            matchSubmissions=False)
+            matchSubmissions=False,
+            enableOrganization=True,
+            enableOrganizationUrl=True,
+            enableDocumentationUrl=True)
 
         params = {
             'name': 'phase 1 updated',
@@ -239,7 +248,10 @@ class PhaseTestCase(base.TestCase):
             'endDate': '2015-04-01T14:00:00.000Z',
             'type': 'type updated',
             'hideScores': False,
-            'matchSubmissions': True
+            'matchSubmissions': True,
+            'enableOrganization': False,
+            'enableOrganizationUrl': False,
+            'enableDocumentationUrl': False
         }
         resp = self.request(path='/challenge_phase/%s' % phase['_id'],
                             method='PUT', user=self.user, params=params)
@@ -260,6 +272,9 @@ class PhaseTestCase(base.TestCase):
         self.assertEqual(resp.json['type'], 'type updated')
         self.assertFalse(resp.json['hideScores'])
         self.assertTrue(resp.json['matchSubmissions'])
+        self.assertFalse(resp.json['enableOrganization'])
+        self.assertFalse(resp.json['enableOrganizationUrl'])
+        self.assertFalse(resp.json['enableDocumentationUrl'])
 
     def testPhaseClearDates(self):
         phase = self.model('phase', 'covalic').createPhase(

--- a/server/models/phase.py
+++ b/server/models/phase.py
@@ -39,7 +39,8 @@ class Phase(AccessControlledModel):
             'active', 'challengeId', 'folderId', 'participantGroupId',
             'groundTruthFolderId', 'testDataFolderId', 'instructions',
             'ordinal', 'startDate', 'endDate', 'type', 'hideScores',
-            'matchSubmissions', 'metrics'})
+            'matchSubmissions', 'enableOrganization', 'enableOrganizationUrl',
+            'enableDocumentationUrl', 'metrics'})
         self.exposeFields(level=AccessType.ADMIN, fields={'scoreTask'})
 
     def list(self, challenge, user=None, limit=50, offset=0, sort=None):
@@ -114,7 +115,9 @@ class Phase(AccessControlledModel):
                     instructions='', active=False, public=True,
                     participantGroup=None, groundTruthFolder=None,
                     testDataFolder=None, startDate=None, endDate=None,
-                    type='', hideScores=False, matchSubmissions=True):
+                    type='', hideScores=False, matchSubmissions=True,
+                    enableOrganization=False, enableOrganizationUrl=False,
+                    enableDocumentationUrl=False):
         """
         Create a new phase for a challenge. Will create a top-level folder under
         the challenge's collection. Will also create a new group for the
@@ -164,6 +167,12 @@ class Phase(AccessControlledModel):
         :param matchSubmissions: Whether to require that submission filenames
             match ground truth filenames.
         :type matchSubmissions: bool
+        :param enableOrganization: Enable submission Organization field.
+        :type enableOrganization: bool
+        :param enableOrganizationUrl: Enable submission Organization URL field.
+        :type enableOrganizationUrl: bool
+        :param enableDocumentationUrl: Enable submission Documentation URL field.
+        :type enableDocumentationUrl: bool
         """
         collection = self.model('collection').load(challenge['collectionId'],
                                                    force=True)
@@ -182,7 +191,10 @@ class Phase(AccessControlledModel):
             'endDate': endDate,
             'type': type,
             'hideScores': hideScores,
-            'matchSubmissions': matchSubmissions
+            'matchSubmissions': matchSubmissions,
+            'enableOrganization': enableOrganization,
+            'enableOrganizationUrl': enableOrganizationUrl,
+            'enableDocumentationUrl': enableDocumentationUrl
         }
         self.validate(phase)
 

--- a/server/models/submission.py
+++ b/server/models/submission.py
@@ -42,7 +42,8 @@ class Submission(Model):
                             'overallScore'))
         self.exposeFields(level=AccessType.READ, fields=(
             '_id', 'creatorId', 'creatorName', 'phaseId', 'folderId', 'created',
-            'score', 'title', 'latest', 'overallScore', 'jobId'
+            'score', 'title', 'latest', 'overallScore', 'jobId', 'organization', 'organizationUrl',
+            'documentationUrl'
         ))
 
     def validate(self, doc):
@@ -116,7 +117,8 @@ class Submission(Model):
             yield result
 
     def createSubmission(self, creator, phase, folder, job=None, title=None,
-                         created=None):
+                         created=None, organization=None, organizationUrl=None,
+                         documentationUrl=None):
         submission = {
             'creatorId': creator['_id'],
             'creatorName': self.getUserName(creator),
@@ -126,6 +128,13 @@ class Submission(Model):
             'score': None,
             'title': title
         }
+
+        if organization is not None:
+            submission['organization'] = organization
+        if organizationUrl is not None:
+            submission['organizationUrl'] = organizationUrl
+        if documentationUrl is not None:
+            submission['documentationUrl'] = documentationUrl
 
         if job is not None:
             submission['jobId'] = job['_id']

--- a/server/rest/phase.py
+++ b/server/rest/phase.py
@@ -100,6 +100,12 @@ class Phase(Resource):
         .param('matchSubmissions', 'Whether to require that submission '
                'filenames match ground truth filenames', dataType='boolean',
                default=True, required=False)
+        .param('enableOrganization', 'Enable submission Organization field.', dataType='boolean',
+               default=False, required=False)
+        .param('enableOrganizationUrl', 'Enable submission Organization URL field.',
+               dataType='boolean', default=False, required=False)
+        .param('enableDocumentationUrl', 'Enable submission Documentation URL field.',
+               dataType='boolean', default=False, required=False)
     )
     def createPhase(self, challenge, params):
         self.requireParams('name', params)
@@ -110,6 +116,9 @@ class Phase(Resource):
         hideScores = self.boolParam('hideScores', params, default=False)
         matchSubmissions = self.boolParam('matchSubmissions', params,
                                           default=True)
+        enableOrganization = self.boolParam('enableOrganization', params, default=False)
+        enableOrganizationUrl = self.boolParam('enableOrganizationUrl', params, default=False)
+        enableDocumentationUrl = self.boolParam('enableDocumentationUrl', params, default=False)
         description = params.get('description', '').strip()
         instructions = params.get('instructions', '').strip()
 
@@ -134,7 +143,10 @@ class Phase(Resource):
             instructions=instructions, active=active, public=public,
             creator=user, challenge=challenge, participantGroup=group,
             ordinal=ordinal, startDate=startDate, endDate=endDate,
-            type=type, hideScores=hideScores, matchSubmissions=matchSubmissions)
+            type=type, hideScores=hideScores, matchSubmissions=matchSubmissions,
+            enableOrganization=enableOrganization, enableOrganizationUrl=enableOrganizationUrl,
+            enableDocumentationUrl=enableDocumentationUrl
+        )
 
         return phase
 
@@ -210,6 +222,12 @@ class Phase(Resource):
         .param('matchSubmissions', 'Whether to require that submission '
                'filenames match ground truth filenames', dataType='boolean',
                default=True, required=False)
+        .param('enableOrganization', 'Enable submission Organization field.', dataType='boolean',
+               default=False, required=False)
+        .param('enableOrganizationUrl', 'Enable submission Organization URL field.',
+               dataType='boolean', default=False, required=False)
+        .param('enableDocumentationUrl', 'Enable submission Documentation URL field.',
+               dataType='boolean', default=False, required=False)
         .errorResponse('ID was invalid.')
         .errorResponse('Write permission denied on the phase.', 403)
     )
@@ -221,6 +239,12 @@ class Phase(Resource):
                                              phase.get('hideScores', False))
         phase['matchSubmissions'] = self.boolParam(
             'matchSubmissions', params, phase.get('matchSubmissions', True))
+        phase['enableOrganization'] = self.boolParam(
+            'enableOrganization', params, phase.get('enableOrganization', False))
+        phase['enableOrganizationUrl'] = self.boolParam(
+            'enableOrganizationUrl', params, phase.get('enableOrganizationUrl', False))
+        phase['enableDocumentationUrl'] = self.boolParam(
+            'enableDocumentationUrl', params, phase.get('enableDocumentationUrl', False))
         phase['name'] = params.get('name', phase['name']).strip()
         phase['description'] = params.get('description',
                                           phase.get('description', '')).strip()

--- a/web_external/models/SubmissionModel.js
+++ b/web_external/models/SubmissionModel.js
@@ -11,7 +11,10 @@ var SubmissionModel = Model.extend({
             data: {
                 folderId: opts.folderId,
                 phaseId: opts.phaseId,
-                title: opts.title
+                title: opts.title,
+                organization: opts.organization,
+                organizationUrl: opts.organizationUrl,
+                documentationUrl: opts.documentationUrl
             }
         }).done((resp) => {
             this.set(resp);

--- a/web_external/router.js
+++ b/web_external/router.js
@@ -96,7 +96,7 @@ router.route('challenge/:id/phase/new', 'newPhase', function (id) {
     events.trigger('g:navigateTo', NewPhaseView, {
         challenge: challenge,
         wizard: {
-            total: 5
+            total: 6
         }
     });
 });
@@ -221,3 +221,6 @@ _wizardPage('phase/:id/input', 'phaseInput', PhaseModel, PhaseInputView);
 
 import PhaseGroundTruthView from './views/body/PhaseGroundTruthView';
 _wizardPage('phase/:id/groundtruth', 'phaseGroundTruth', PhaseModel, PhaseGroundTruthView);
+
+import PhaseConfigureSubmissionsView from './views/body/PhaseConfigureSubmissionsView';
+_wizardPage('phase/:id/configure_submissions', 'phaseConfigureSubmission', PhaseModel, PhaseConfigureSubmissionsView);

--- a/web_external/stylesheets/body/phasePage.styl
+++ b/web_external/stylesheets/body/phasePage.styl
@@ -15,9 +15,6 @@
   .c-phase-training
     float right
 
-  .c-phase-match-submission
-    float right
-
   .c-phase-privacy
     overflow auto
 

--- a/web_external/stylesheets/body/submitPage.styl
+++ b/web_external/stylesheets/body/submitPage.styl
@@ -13,7 +13,7 @@
   border 1px solid #d9d9b5
   background-color #fafaea
 
-  .c-submission-title-error
+  .c-submission-validation-error
     color #d44
     margin-top 5px
     font-weight bold

--- a/web_external/stylesheets/body/userSubmissionsPage.styl
+++ b/web_external/stylesheets/body/userSubmissionsPage.styl
@@ -40,7 +40,11 @@
 
   tbody
     .c-submission-title
-      width 25%
+      width 15%
+    .c-submission-organization
+      width 15%
+    .c-submission-documentation
+      width 5%
     .c-submission-status
       width 10%
     .c-submission-date
@@ -50,6 +54,7 @@
     .c-submission-download>a
     .c-submission-json>a
       color #777
+      whitespace nowrap
 
 .c-job-log-tooltip-inner
   white-space pre

--- a/web_external/templates/body/newPhasePage.pug
+++ b/web_external/templates/body/newPhasePage.pug
@@ -37,10 +37,6 @@ include ../mixins/wizardMixins
           |  Hide scores from participants
       .checkbox
         label
-          input#c-phase-match-submissions(type="checkbox", checked="checked")
-          |  Require submission filenames to match ground truth filenames
-      .checkbox
-        label
           input#c-phase-training(type="checkbox")
           |  Training phase
     .g-validation-failed-message

--- a/web_external/templates/body/phaseConfigureSubmissionsPage.pug
+++ b/web_external/templates/body/phaseConfigureSubmissionsPage.pug
@@ -1,0 +1,23 @@
+include ../mixins/backMixins
+include ../mixins/wizardMixins
+
+.c-wizard-page-container
+  .c-page-title Configure submissions
+
+  p.
+    Configure options for submissions to this phase.
+
+  .c-form-container
+    form.c-phase-configure-submissions-form
+      .checkbox
+        label
+          input#c-phase-match-submissions(type="checkbox", checked=(phase.get('matchSubmissions') ? 'checked' : undefined))
+          |  Require submission filenames to match ground truth filenames
+    .g-validation-failed-message
+
+  if wizard
+    .c-wizard-nav-container
+      +wizardNav(wizard.current, wizard.total)
+  else
+    button.btn.btn-primary.c-save-options #[i.icon-ok] Save
+    +backToModel(phase, '#phase/' + phase.id)

--- a/web_external/templates/body/phaseConfigureSubmissionsPage.pug
+++ b/web_external/templates/body/phaseConfigureSubmissionsPage.pug
@@ -13,6 +13,18 @@ include ../mixins/wizardMixins
         label
           input#c-phase-match-submissions(type="checkbox", checked=(phase.get('matchSubmissions') ? 'checked' : undefined))
           |  Require submission filenames to match ground truth filenames
+      .checkbox
+        label
+          input#c-phase-enable-organization(type="checkbox", checked=(phase.get('enableOrganization') ? 'checked' : undefined))
+          |  Enable Organization field
+      .checkbox
+        label
+          input#c-phase-enable-organization-url(type="checkbox", checked=(phase.get('enableOrganizationUrl') ? 'checked' : undefined))
+          |  Enable Organization URL field
+      .checkbox
+        label
+          input#c-phase-enable-documentation-url(type="checkbox", checked=(phase.get('enableDocumentationUrl') ? 'checked' : undefined))
+          |  Enable Documentation URL field
     .g-validation-failed-message
 
   if wizard

--- a/web_external/templates/body/phasePage.pug
+++ b/web_external/templates/body/phasePage.pug
@@ -26,6 +26,10 @@
                             a.c-edit-metrics(role="menuitem", href=`#phase/${phase.id}/metrics`)
                               i.icon-chart-bar
                               |  Scoring metrics
+                        li(role="presentation")
+                          a.c-configure-submissions(href=`#phase/${phase.id}/configure_submissions`, role="menuitem")
+                            i.icon-upload
+                            |  Configure submissions
                         if phase.getAccessLevel() >= AccessType.ADMIN
                             li.divider(role="presentation")
                             li(role="presentation")

--- a/web_external/templates/body/submitPage.pug
+++ b/web_external/templates/body/submitPage.pug
@@ -13,10 +13,10 @@
     p.
       To submit to this phase of the challenge, upload your output files here.
   p.
-    Before you upload your submission, please add a short title that identifies
-    either your organization or your algorithm. This title doesn't have to be
+    Before uploading your submission, please fill out the information below,
+    including a short title that describes your submission. This title doesn't have to be
     unique, but it will appear in the leaderboard with your submission. The title
-    should be no more than #{maxTitleLength} characters.
+    should be no more than #{maxTextLength} characters.
   p.
     Use the button below to select all of the files, or drag and drop them onto
     the button. If the selection is valid, you can upload them. Once done, your
@@ -25,7 +25,20 @@
 
 .c-submit-uploader-container
   .c-submission-mismatch-container
-  label Enter submission title
-  input.c-submission-title-input.form-control(type="text", maxlength=maxTitleLength)
-  .c-submission-title-error
+  .form-group
+    label Submission title
+    input.c-submission-title-input.form-control(type="text", maxlength=maxTextLength)
+  if phase.get('enableOrganization')
+    .form-group
+      label Organization or team name
+      input.c-submission-organization-input.form-control(type="text", maxlength=maxTextLength)
+  if phase.get('enableOrganizationUrl')
+    .form-group
+      label URL for organization or team
+      input.c-submission-organization-url-input.form-control(type="text", maxlength=maxUrlLength)
+  if phase.get('enableDocumentationUrl')
+    .form-group
+      label URL for documentation about your submission
+      input.c-submission-documentation-url-input.form-control(type="text", maxlength=maxUrlLength)
+  .c-submission-validation-error
   .c-submit-upload-widget

--- a/web_external/templates/body/userSubmissionsPage.pug
+++ b/web_external/templates/body/userSubmissionsPage.pug
@@ -2,6 +2,9 @@
 - var hasSuccessfulSubmission = false
 - var endOfSubmissions = !submissions.hasNextPage()
 - var successText = JobStatus.text(JobStatus.SUCCESS)
+- var enableOrganization = phase.get('enableOrganization')
+- var enableOrganizationUrl = phase.get('enableOrganizationUrl')
+- var enableDocumentationUrl = phase.get('enableDocumentationUrl')
 
 .c-user-submissions-panel.panel.panel-default
   .c-user-submissions-user-info.panel-heading.clearfix
@@ -18,6 +21,10 @@
       thead
         tr
           th Title
+          if enableOrganization
+            th Organization
+          if enableDocumentationUrl
+            th Documentation
           th Latest
           th Status
           th Date
@@ -32,6 +39,19 @@
           tr
             td.c-submission-title
               a(href=`#submission/${submission.id}`)= submission.get('title') || '--'
+            if enableOrganization
+              td.c-submission-organization
+                if enableOrganizationUrl && submission.get('organizationUrl')
+                  a(href=submission.get('organizationUrl'))= submission.get('organization') || '--'
+                else
+                  = submission.get('organization') || '--'
+            if enableDocumentationUrl
+              td.c-submission-documentation
+                if submission.get('documentationUrl')
+                  a(href=submission.get('documentationUrl'))
+                    i.icon-doc-text
+                else
+                  | --
             td.c-submission-latest
               if submission.get('latest')
                 i.icon-ok

--- a/web_external/templates/widgets/editPhaseWidget.pug
+++ b/web_external/templates/widgets/editPhaseWidget.pug
@@ -26,10 +26,6 @@
             |  Hide scores from participants
         .checkbox
           label
-            input#c-phase-match-submissions(type="checkbox")
-            |  Require submission filenames to match ground truth filenames
-        .checkbox
-          label
             input#c-phase-training(type="checkbox")
             |  Training phase
         .g-validation-failed-message

--- a/web_external/templates/widgets/leaderboard.pug
+++ b/web_external/templates/widgets/leaderboard.pug
@@ -1,4 +1,7 @@
 - var phaseAdmin = phase.getAccessLevel() >= AccessType.ADMIN
+- var enableOrganization = phase.get('enableOrganization')
+- var enableOrganizationUrl = phase.get('enableOrganizationUrl')
+- var enableDocumentationUrl = phase.get('enableDocumentationUrl')
 
 table.table.table-striped.table-condensed.c-leaderboard-table
   thead
@@ -6,6 +9,10 @@ table.table.table-striped.table-condensed.c-leaderboard-table
       th.c-rank Rank
       th User
       th Title
+      if enableOrganization
+        th Organization
+      if phaseAdmin && enableDocumentationUrl
+        th Documentation
       th Date
       th Score
   tbody
@@ -20,6 +27,20 @@ table.table.table-striped.table-condensed.c-leaderboard-table
           else
             = submission.get('creatorName')
         td= submission.get('title') || '--'
+        if enableOrganization
+          td
+            if phaseAdmin && enableOrganizationUrl && submission.get('organizationUrl')
+              a.c-organization-link(
+                href=submission.get('organizationUrl'))= submission.get('organization') || '--'
+            else
+              = submission.get('organization') || '--'
+        if phaseAdmin && enableDocumentationUrl
+          td
+            if submission.get('documentationUrl')
+              a.c-documentation-link(href=submission.get('documentationUrl'))
+                i.icon-doc-text
+            else
+              | --
         - var date = moment(submission.get('created'))
         - var dateStr = date.format('ddd, D MMM YYYY, h:mm:ss a')
         - var dateFromNow = date.fromNow()

--- a/web_external/views/body/NewPhaseView.js
+++ b/web_external/views/body/NewPhaseView.js
@@ -18,8 +18,7 @@ var NewPhaseView = View.extend({
                 hideScores: this.$('#c-phase-hide-scores').is(':checked'),
                 startDate: this.dateTimeRangeWidget.fromDateString(),
                 endDate: this.dateTimeRangeWidget.toDateString(),
-                type: this.$('#c-phase-training').is(':checked') ? 'training' : '',
-                matchSubmissions: this.$('#c-phase-match-submissions').is(':checked')
+                type: this.$('#c-phase-training').is(':checked') ? 'training' : ''
             });
 
             phase.on('g:saved', function () {

--- a/web_external/views/body/PhaseConfigureSubmissionsView.js
+++ b/web_external/views/body/PhaseConfigureSubmissionsView.js
@@ -25,7 +25,10 @@ var PhaseConfigureSubmissionsView = View.extend({
 
     _save: function (onSuccess) {
         var fields = {
-            matchSubmissions: this.$('#c-phase-match-submissions').is(':checked')
+            matchSubmissions: this.$('#c-phase-match-submissions').is(':checked'),
+            enableOrganization: this.$('#c-phase-enable-organization').is(':checked'),
+            enableOrganizationUrl: this.$('#c-phase-enable-organization-url').is(':checked'),
+            enableDocumentationUrl: this.$('#c-phase-enable-documentation-url').is(':checked')
         };
 
         this.model.set(fields);

--- a/web_external/views/body/PhaseConfigureSubmissionsView.js
+++ b/web_external/views/body/PhaseConfigureSubmissionsView.js
@@ -1,0 +1,57 @@
+import events from 'girder/events';
+import router from '../../router';
+import View from '../view';
+import template from '../../templates/body/phaseConfigureSubmissionsPage.pug';
+
+var PhaseConfigureSubmissionsView = View.extend({
+    events: {
+        'click .c-wizard-next-button': function () {
+            this._save(() => {
+                router.navigate(`phase/${this.model.id}`, {trigger: true});
+            });
+        },
+
+        'click .c-save-options': function () {
+            this._save(() => {
+                events.trigger('g:alert', {
+                    text: 'Settings saved.',
+                    type: 'success',
+                    icon: 'ok',
+                    timeout: 3000
+                });
+            });
+        }
+    },
+
+    _save: function (onSuccess) {
+        var fields = {
+            matchSubmissions: this.$('#c-phase-match-submissions').is(':checked')
+        };
+
+        this.model.set(fields);
+        this.model.once('g:saved', onSuccess);
+        this.model.off('g:error').on('g:error', (err) => {
+            this.$('.g-validation-failed-message').text(err.responseJSON.message);
+            this.$(`#c-phase-${err.responseJSON.field}`).focus();
+        }).save();
+
+        this.$('.g-validation-failed-message').text('');
+    },
+
+    initialize: function (settings) {
+        this.wizard = settings.wizard || false;
+
+        this.render();
+    },
+
+    render: function () {
+        this.$el.html(template({
+            wizard: this.wizard,
+            phase: this.model
+        }));
+
+        return this;
+    }
+});
+
+export default PhaseConfigureSubmissionsView;

--- a/web_external/views/body/PhaseGroundTruthView.js
+++ b/web_external/views/body/PhaseGroundTruthView.js
@@ -12,7 +12,9 @@ var PhaseGroundTruthView = View.extend({
     events: {
         'click .c-wizard-next-button': function () {
             this.accessWidget.once('g:accessListSaved', function () {
-                router.navigate('phase/' + this.model.id, {trigger: true});
+                this._saveAndGoTo('phase/' + this.model.id +
+                  '/configure_submissions?wizard&curr=' + (this.wizard.current + 1) +
+                  '&total=' + this.wizard.total);
             }, this).saveAccessList();
         },
 
@@ -58,7 +60,7 @@ var PhaseGroundTruthView = View.extend({
             router.navigate(route, {trigger: true});
         }, this).set({
 
-        }).saveAccessList();
+        }).save();
     },
 
     initialize: function (settings) {

--- a/web_external/views/body/SubmissionView.js
+++ b/web_external/views/body/SubmissionView.js
@@ -58,7 +58,10 @@ var SubmissionView = View.extend({
             }, this).postSubmission({
                 phaseId: this.submission.get('phaseId'),
                 folderId: this.submission.get('folderId'),
-                title: this.submission.get('title')
+                title: this.submission.get('title'),
+                organization: this.submission.get('organization'),
+                organizationUrl: this.submission.get('organizationUrl'),
+                documentationUrl: this.submission.get('documentationUrl')
             });
         },
 

--- a/web_external/views/body/UserSubmissionsView.js
+++ b/web_external/views/body/UserSubmissionsView.js
@@ -88,6 +88,7 @@ var UserSubmissionsView = View.extend({
     render: function (params) {
         this.$el.html(template({
             user: this.user,
+            phase: this.phase,
             submissions: this.submissions,
             getShortLog: this._getShortLog,
             JobStatus,

--- a/web_external/views/widgets/EditPhaseWidget.js
+++ b/web_external/views/widgets/EditPhaseWidget.js
@@ -18,8 +18,7 @@ var EditPhaseWidget = View.extend({
                 hideScores: this.$('#c-phase-hide-scores').is(':checked'),
                 startDate: this.dateTimeRangeWidget.fromDateString(),
                 endDate: this.dateTimeRangeWidget.toDateString(),
-                type: this.$('#c-phase-training').is(':checked') ? 'training' : '',
-                matchSubmissions: this.$('#c-phase-match-submissions').is(':checked')
+                type: this.$('#c-phase-training').is(':checked') ? 'training' : ''
             };
 
             if (this.model) {
@@ -74,15 +73,6 @@ var EditPhaseWidget = View.extend({
                     view.$('#c-phase-hide-scores').attr('checked', 'checked');
                 } else {
                     view.$('#c-phase-hide-scores').removeAttr('checked');
-                }
-                var matchSubmissions = view.model.get('matchSubmissions');
-                if (_.isUndefined(matchSubmissions)) {
-                    matchSubmissions = true;
-                }
-                if (matchSubmissions) {
-                    view.$('#c-phase-match-submissions').attr('checked', 'checked');
-                } else {
-                    view.$('#c-phase-match-submissions').removeAttr('checked');
                 }
 
                 view.dateTimeRangeWidget.setElement(view.$('#c-phase-timeframe')).render();


### PR DESCRIPTION
This allows entering more metadata about a submission. Now, instead of supplying only a title along with a submission, the phase can be configured to additionally require any of the following pre-defined fields:

- Organization
- Organization URL
- Documentation URL

Some of this information is displayed in the leaderboard, but currently it's conservative in that the URLs are visible only to phase admins.

This fixes https://github.com/girder/covalic/issues/182 (somewhat) and should address the immediate needs of the 2017 ISIC Challenge.