### PR TITLE
Include girder_app.js

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -78,6 +78,7 @@ class CustomAppRoot(ModelImporter):
         <div id="g-global-info-apiroot" class="hide">${apiRoot}</div>
         <div id="g-global-info-staticroot" class="hide">${staticRoot}</div>
         <script src="${staticRoot}/built/girder_lib.min.js"></script>
+        <script src="${staticRoot}/built/girder_app.min.js"></script>
         % for plugin in pluginJs:
           <script src="${staticRoot}/built/plugins/${plugin}/plugin.min.js"></script>
         % endfor


### PR DESCRIPTION
This fixes missing girder symbols when loading the web front-end.