### PR TITLE
Add phase options to make submission fields optional

### DIFF
--- a/plugin_tests/phase_test.py
+++ b/plugin_tests/phase_test.py
@@ -190,7 +190,10 @@ class PhaseTestCase(base.TestCase):
             matchSubmissions=False,
             enableOrganization=True,
             enableOrganizationUrl=True,
-            enableDocumentationUrl=True)
+            enableDocumentationUrl=True,
+            requireOrganization=False,
+            requireOrganizationUrl=False,
+            requireDocumentationUrl=False)
 
         resp = self.request(path='/challenge_phase/%s' % phase['_id'],
                             user=self.user)
@@ -215,6 +218,9 @@ class PhaseTestCase(base.TestCase):
         self.assertTrue(resp.json['enableOrganization'])
         self.assertTrue(resp.json['enableOrganizationUrl'])
         self.assertTrue(resp.json['enableDocumentationUrl'])
+        self.assertFalse(resp.json['requireOrganization'])
+        self.assertFalse(resp.json['requireOrganizationUrl'])
+        self.assertFalse(resp.json['requireDocumentationUrl'])
 
     def testGetPhaseInvalid(self):
         resp = self.request(path='/challenge_phase/1', user=self.user)
@@ -236,7 +242,10 @@ class PhaseTestCase(base.TestCase):
             matchSubmissions=False,
             enableOrganization=True,
             enableOrganizationUrl=True,
-            enableDocumentationUrl=True)
+            enableDocumentationUrl=True,
+            requireOrganization=False,
+            requireOrganizationUrl=False,
+            requireDocumentationUrl=False)
 
         params = {
             'name': 'phase 1 updated',
@@ -251,7 +260,10 @@ class PhaseTestCase(base.TestCase):
             'matchSubmissions': True,
             'enableOrganization': False,
             'enableOrganizationUrl': False,
-            'enableDocumentationUrl': False
+            'enableDocumentationUrl': False,
+            'requireOrganization': True,
+            'requireOrganizationUrl': True,
+            'requireDocumentationUrl': True
         }
         resp = self.request(path='/challenge_phase/%s' % phase['_id'],
                             method='PUT', user=self.user, params=params)
@@ -275,6 +287,9 @@ class PhaseTestCase(base.TestCase):
         self.assertFalse(resp.json['enableOrganization'])
         self.assertFalse(resp.json['enableOrganizationUrl'])
         self.assertFalse(resp.json['enableDocumentationUrl'])
+        self.assertTrue(resp.json['requireOrganization'])
+        self.assertTrue(resp.json['requireOrganizationUrl'])
+        self.assertTrue(resp.json['requireDocumentationUrl'])
 
     def testPhaseClearDates(self):
         phase = self.model('phase', 'covalic').createPhase(

--- a/server/models/phase.py
+++ b/server/models/phase.py
@@ -40,7 +40,8 @@ class Phase(AccessControlledModel):
             'groundTruthFolderId', 'testDataFolderId', 'instructions',
             'ordinal', 'startDate', 'endDate', 'type', 'hideScores',
             'matchSubmissions', 'enableOrganization', 'enableOrganizationUrl',
-            'enableDocumentationUrl', 'metrics'})
+            'enableDocumentationUrl', 'requireOrganization',
+            'requireOrganizationUrl', 'requireDocumentationUrl', 'metrics'})
         self.exposeFields(level=AccessType.ADMIN, fields={'scoreTask'})
 
     def list(self, challenge, user=None, limit=50, offset=0, sort=None):
@@ -117,7 +118,8 @@ class Phase(AccessControlledModel):
                     testDataFolder=None, startDate=None, endDate=None,
                     type='', hideScores=False, matchSubmissions=True,
                     enableOrganization=False, enableOrganizationUrl=False,
-                    enableDocumentationUrl=False):
+                    enableDocumentationUrl=False, requireOrganization=False,
+                    requireOrganizationUrl=False, requireDocumentationUrl=False):
         """
         Create a new phase for a challenge. Will create a top-level folder under
         the challenge's collection. Will also create a new group for the
@@ -173,6 +175,12 @@ class Phase(AccessControlledModel):
         :type enableOrganizationUrl: bool
         :param enableDocumentationUrl: Enable submission Documentation URL field.
         :type enableDocumentationUrl: bool
+        :param requireOrganization: Require submission Organization field.
+        :type requireOrganization: bool
+        :param requireOrganizationUrl: Require submission Organization URL field.
+        :type requireOrganizationUrl: bool
+        :param requireDocumentationUrl: Require submission Documentation URL field.
+        :type requireDocumentationUrl: bool
         """
         collection = self.model('collection').load(challenge['collectionId'],
                                                    force=True)
@@ -194,7 +202,10 @@ class Phase(AccessControlledModel):
             'matchSubmissions': matchSubmissions,
             'enableOrganization': enableOrganization,
             'enableOrganizationUrl': enableOrganizationUrl,
-            'enableDocumentationUrl': enableDocumentationUrl
+            'enableDocumentationUrl': enableDocumentationUrl,
+            'requireOrganization': requireOrganization,
+            'requireOrganizationUrl': requireOrganizationUrl,
+            'requireDocumentationUrl': requireDocumentationUrl
         }
         self.validate(phase)
 

--- a/server/rest/phase.py
+++ b/server/rest/phase.py
@@ -106,6 +106,12 @@ class Phase(Resource):
                dataType='boolean', default=False, required=False)
         .param('enableDocumentationUrl', 'Enable submission Documentation URL field.',
                dataType='boolean', default=False, required=False)
+        .param('requireOrganization', 'Require submission Organization field.', dataType='boolean',
+               default=True, required=False)
+        .param('requireOrganizationUrl', 'Require submission Organization URL field.',
+               dataType='boolean', default=True, required=False)
+        .param('requireDocumentationUrl', 'Require submission Documentation URL field.',
+               dataType='boolean', default=True, required=False)
     )
     def createPhase(self, challenge, params):
         self.requireParams('name', params)
@@ -119,6 +125,9 @@ class Phase(Resource):
         enableOrganization = self.boolParam('enableOrganization', params, default=False)
         enableOrganizationUrl = self.boolParam('enableOrganizationUrl', params, default=False)
         enableDocumentationUrl = self.boolParam('enableDocumentationUrl', params, default=False)
+        requireOrganization = self.boolParam('requireOrganization', params, default=True)
+        requireOrganizationUrl = self.boolParam('requireOrganizationUrl', params, default=True)
+        requireDocumentationUrl = self.boolParam('requireDocumentationUrl', params, default=True)
         description = params.get('description', '').strip()
         instructions = params.get('instructions', '').strip()
 
@@ -145,7 +154,10 @@ class Phase(Resource):
             ordinal=ordinal, startDate=startDate, endDate=endDate,
             type=type, hideScores=hideScores, matchSubmissions=matchSubmissions,
             enableOrganization=enableOrganization, enableOrganizationUrl=enableOrganizationUrl,
-            enableDocumentationUrl=enableDocumentationUrl
+            enableDocumentationUrl=enableDocumentationUrl,
+            requireOrganization=requireOrganization,
+            requireOrganizationUrl=requireOrganizationUrl,
+            requireDocumentationUrl=requireDocumentationUrl
         )
 
         return phase
@@ -228,6 +240,12 @@ class Phase(Resource):
                dataType='boolean', default=False, required=False)
         .param('enableDocumentationUrl', 'Enable submission Documentation URL field.',
                dataType='boolean', default=False, required=False)
+        .param('requireOrganization', 'Require submission Organization field.', dataType='boolean',
+               default=True, required=False)
+        .param('requireOrganizationUrl', 'Require submission Organization URL field.',
+               dataType='boolean', default=True, required=False)
+        .param('requireDocumentationUrl', 'Require submission Documentation URL field.',
+               dataType='boolean', default=True, required=False)
         .errorResponse('ID was invalid.')
         .errorResponse('Write permission denied on the phase.', 403)
     )
@@ -245,6 +263,12 @@ class Phase(Resource):
             'enableOrganizationUrl', params, phase.get('enableOrganizationUrl', False))
         phase['enableDocumentationUrl'] = self.boolParam(
             'enableDocumentationUrl', params, phase.get('enableDocumentationUrl', False))
+        phase['requireOrganization'] = self.boolParam(
+            'requireOrganization', params, phase.get('requireOrganization', True))
+        phase['requireOrganizationUrl'] = self.boolParam(
+            'requireOrganizationUrl', params, phase.get('requireOrganizationUrl', True))
+        phase['requireDocumentationUrl'] = self.boolParam(
+            'requireDocumentationUrl', params, phase.get('requireDocumentationUrl', True))
         phase['name'] = params.get('name', phase['name']).strip()
         phase['description'] = params.get('description',
                                           phase.get('description', '')).strip()

--- a/server/rest/submission.py
+++ b/server/rest/submission.py
@@ -75,6 +75,31 @@ class Submission(Resource):
 
         return submission
 
+    def _checkRequireParam(self, phase, params, paramName, requireOptionName):
+        """
+        Require a parameter conditionally, based on a phase property.
+
+        :param phase: The phase.
+        :param params: Parameters.
+        :param paramName: Parameter name.
+        :param requireOptionName: Phase property that indicates whether the parameter is required.
+        """
+        if phase.get(requireOptionName, False):
+            self.requireParams(paramName, params)
+
+    def _getStrippedParam(self, params, name):
+        """
+        Return the stripped parameter, or None if the parameter doesn't exist.
+
+        :param params: Parameters.
+        :param name: Parameter name.
+        :return: The stripped parameter, or None.
+        """
+        param = params.get(name)
+        if param is not None:
+            param = param.strip()
+        return param
+
     @access.public
     @loadmodel(map={'phaseId': 'phase'}, model='phase', plugin='covalic',
                level=AccessType.READ)
@@ -162,14 +187,14 @@ class Submission(Resource):
         organizationUrl = None
         documentationUrl = None
         if phase.get('enableOrganization', False):
-            self.requireParams('organization', params)
-            organization = params['organization'].strip()
+            self._checkRequireParam(phase, params, 'organization', 'requireOrganization')
+            organization = self._getStrippedParam(params, 'organization')
         if phase.get('enableOrganizationUrl', False):
-            self.requireParams('organizationUrl', params)
-            organizationUrl = params['organizationUrl'].strip()
+            self._checkRequireParam(phase, params, 'organizationUrl', 'requireOrganizationUrl')
+            organizationUrl = self._getStrippedParam(params, 'organizationUrl')
         if phase.get('enableDocumentationUrl', False):
-            self.requireParams('documentationUrl', params)
-            documentationUrl = params['documentationUrl'].strip()
+            self._checkRequireParam(phase, params, 'documentationUrl', 'requireDocumentationUrl')
+            documentationUrl = self._getStrippedParam(params, 'documentationUrl')
 
         # Site admins may override the submission creation date
         created = None

--- a/web_external/models/PhaseModel.js
+++ b/web_external/models/PhaseModel.js
@@ -88,6 +88,30 @@ var PhaseModel = AccessControlledModel.extend({
         }).error((err) => {
             this.trigger('c:error', err);
         });
+    },
+
+    enableOrganization: function () {
+        return this.get('enableOrganization');
+    },
+
+    requireOrganization: function () {
+        return !this.has('requireOrganization') || this.get('requireOrganization');
+    },
+
+    enableOrganizationUrl: function () {
+        return this.get('enableOrganizationUrl');
+    },
+
+    requireOrganizationUrl: function () {
+        return !this.has('requireOrganizationUrl') || this.get('requireOrganizationUrl');
+    },
+
+    enableDocumentationUrl: function () {
+        return this.get('enableDocumentationUrl');
+    },
+
+    requireDocumentationUrl: function () {
+        return !this.has('requireDocumentationUrl') || this.get('requireDocumentationUrl');
     }
 });
 

--- a/web_external/templates/body/phaseConfigureSubmissionsPage.pug
+++ b/web_external/templates/body/phaseConfigureSubmissionsPage.pug
@@ -8,6 +8,7 @@ include ../mixins/wizardMixins
     Configure options for submissions to this phase.
 
   .c-form-container
+    //- TODO improve layout, connect 'require' checkbox sensitivities to 'enable' checkboxes
     form.c-phase-configure-submissions-form
       .checkbox
         label
@@ -15,16 +16,28 @@ include ../mixins/wizardMixins
           |  Require submission filenames to match ground truth filenames
       .checkbox
         label
-          input#c-phase-enable-organization(type="checkbox", checked=(phase.get('enableOrganization') ? 'checked' : undefined))
+          input#c-phase-enable-organization(type="checkbox", checked=(phase.enableOrganization() ? 'checked' : undefined))
           |  Enable Organization field
       .checkbox
         label
-          input#c-phase-enable-organization-url(type="checkbox", checked=(phase.get('enableOrganizationUrl') ? 'checked' : undefined))
+          input#c-phase-enable-organization-url(type="checkbox", checked=(phase.enableOrganizationUrl() ? 'checked' : undefined))
           |  Enable Organization URL field
       .checkbox
         label
-          input#c-phase-enable-documentation-url(type="checkbox", checked=(phase.get('enableDocumentationUrl') ? 'checked' : undefined))
+          input#c-phase-enable-documentation-url(type="checkbox", checked=(phase.enableDocumentationUrl() ? 'checked' : undefined))
           |  Enable Documentation URL field
+      .checkbox
+        label
+          input#c-phase-require-organization(type="checkbox", checked=(phase.requireOrganization() ? 'checked' : undefined))
+          |  Require Organization field
+      .checkbox
+        label
+          input#c-phase-require-organization-url(type="checkbox", checked=(phase.requireOrganizationUrl() ? 'checked' : undefined))
+          |  Require Organization URL field
+      .checkbox
+        label
+          input#c-phase-require-documentation-url(type="checkbox", checked=(phase.requireDocumentationUrl() ? 'checked' : undefined))
+          |  Require Documentation URL field
     .g-validation-failed-message
 
   if wizard

--- a/web_external/templates/body/submitPage.pug
+++ b/web_external/templates/body/submitPage.pug
@@ -28,17 +28,26 @@
   .form-group
     label Submission title
     input.c-submission-title-input.form-control(type="text", maxlength=maxTextLength)
-  if phase.get('enableOrganization')
+  if phase.enableOrganization()
     .form-group
-      label Organization or team name
+      label
+        | Organization or team name
+        if !phase.requireOrganization()
+          |  (optional)
       input.c-submission-organization-input.form-control(type="text", maxlength=maxTextLength)
-  if phase.get('enableOrganizationUrl')
+  if phase.enableOrganizationUrl()
     .form-group
-      label URL for organization or team
+      label
+        | URL for organization or team
+        if !phase.requireOrganizationUrl()
+          |  (optional)
       input.c-submission-organization-url-input.form-control(type="text", maxlength=maxUrlLength)
-  if phase.get('enableDocumentationUrl')
+  if phase.enableDocumentationUrl()
     .form-group
-      label URL for documentation about your submission
+      label
+        | URL for documentation about your submission
+        if !phase.requireDocumentationUrl()
+          |  (optional)
       input.c-submission-documentation-url-input.form-control(type="text", maxlength=maxUrlLength)
   .c-submission-validation-error
   .c-submit-upload-widget

--- a/web_external/templates/body/userSubmissionsPage.pug
+++ b/web_external/templates/body/userSubmissionsPage.pug
@@ -2,9 +2,9 @@
 - var hasSuccessfulSubmission = false
 - var endOfSubmissions = !submissions.hasNextPage()
 - var successText = JobStatus.text(JobStatus.SUCCESS)
-- var enableOrganization = phase.get('enableOrganization')
-- var enableOrganizationUrl = phase.get('enableOrganizationUrl')
-- var enableDocumentationUrl = phase.get('enableDocumentationUrl')
+- var enableOrganization = phase.enableOrganization()
+- var enableOrganizationUrl = phase.enableOrganizationUrl()
+- var enableDocumentationUrl = phase.enableDocumentationUrl()
 
 .c-user-submissions-panel.panel.panel-default
   .c-user-submissions-user-info.panel-heading.clearfix

--- a/web_external/templates/widgets/leaderboard.pug
+++ b/web_external/templates/widgets/leaderboard.pug
@@ -1,7 +1,7 @@
 - var phaseAdmin = phase.getAccessLevel() >= AccessType.ADMIN
-- var enableOrganization = phase.get('enableOrganization')
-- var enableOrganizationUrl = phase.get('enableOrganizationUrl')
-- var enableDocumentationUrl = phase.get('enableDocumentationUrl')
+- var enableOrganization = phase.enableOrganization()
+- var enableOrganizationUrl = phase.enableOrganizationUrl()
+- var enableDocumentationUrl = phase.enableDocumentationUrl()
 
 table.table.table-striped.table-condensed.c-leaderboard-table
   thead

--- a/web_external/views/body/PhaseConfigureSubmissionsView.js
+++ b/web_external/views/body/PhaseConfigureSubmissionsView.js
@@ -28,7 +28,10 @@ var PhaseConfigureSubmissionsView = View.extend({
             matchSubmissions: this.$('#c-phase-match-submissions').is(':checked'),
             enableOrganization: this.$('#c-phase-enable-organization').is(':checked'),
             enableOrganizationUrl: this.$('#c-phase-enable-organization-url').is(':checked'),
-            enableDocumentationUrl: this.$('#c-phase-enable-documentation-url').is(':checked')
+            enableDocumentationUrl: this.$('#c-phase-enable-documentation-url').is(':checked'),
+            requireOrganization: this.$('#c-phase-require-organization').is(':checked'),
+            requireOrganizationUrl: this.$('#c-phase-require-organization-url').is(':checked'),
+            requireDocumentationUrl: this.$('#c-phase-require-documentation-url').is(':checked')
         };
 
         this.model.set(fields);

--- a/web_external/views/body/SubmitView.js
+++ b/web_external/views/body/SubmitView.js
@@ -87,15 +87,15 @@ var SubmitView = View.extend({
             this.$('input.c-submission-title').focus();
             errorText = 'Please enter a title for your submission.';
             valid = false;
-        } else if (this.phase.get('enableOrganization') && _.isEmpty(this.organization)) {
+        } else if (this.phase.enableOrganization() && this.phase.requireOrganization() && _.isEmpty(this.organization)) {
             this.$('input.c-submission-organization').focus();
             errorText = 'Please enter an organization or team name.';
             valid = false;
-        } else if (this.phase.get('enableOrganizationUrl') && _.isEmpty(this.organizationUrl)) {
+        } else if (this.phase.enableOrganizationUrl() && this.phase.requireOrganizationUrl() && _.isEmpty(this.organizationUrl)) {
             this.$('input.c-submission-organization-url').focus();
             errorText = 'Please enter a URL for the organization or team.';
             valid = false;
-        } else if (this.phase.get('enableDocumentationUrl') && _.isEmpty(this.documentationUrl)) {
+        } else if (this.phase.enableDocumentationUrl() && this.phase.requireDocumentationUrl() && _.isEmpty(this.documentationUrl)) {
             this.$('input.c-submission-documentation-url').focus();
             errorText = 'Please enter a URL for documentation about your submission.';
             valid = false;


### PR DESCRIPTION
The following submission fields gain an option to control whether or not
they are required (when enabled):
- enableOrganization
- enableOrganizationUrl
- enableDocumentationUrl

For backwards compatibility, the 'required' options are enabled by
default.

A TODO note is left in the Configure Submissions view about possible
future improvements to the user interface.