### PR TITLE
Enable disqualifying a submission

### DIFF
--- a/server/rest/submission.py
+++ b/server/rest/submission.py
@@ -325,6 +325,8 @@ class Submission(Resource):
                required=False)
         .param('documentationUrl', 'URL of documentation associated with the submission.',
                required=False)
+        .param('disqualify', 'Whether to disqualify the submission so that it does not '
+               'appear in the leaderboard.', dataType='boolean', required=False)
         .errorResponse('ID was invalid.')
         .errorResponse('Site admin access is required.', 403)
     )
@@ -352,6 +354,10 @@ class Submission(Resource):
         documentationUrl = self._getStrippedParam(params, 'documentationUrl')
         if documentationUrl is not None:
             submission['documentationUrl'] = documentationUrl
+
+        disqualify = self.boolParam('disqualify', params, default=False)
+        if disqualify:
+            submission['latest'] = False
 
         submission = self.model('submission', 'covalic').save(submission)
 

--- a/server/rest/submission.py
+++ b/server/rest/submission.py
@@ -325,8 +325,8 @@ class Submission(Resource):
                required=False)
         .param('documentationUrl', 'URL of documentation associated with the submission.',
                required=False)
-        .param('disqualify', 'Whether to disqualify the submission so that it does not '
-               'appear in the leaderboard.', dataType='boolean', required=False)
+        .param('disqualified', 'Whether the submission is disqualified. Disqualified '
+               'submissions do not appear in the leaderboard.', dataType='boolean', required=False)
         .errorResponse('ID was invalid.')
         .errorResponse('Site admin access is required.', 403)
     )
@@ -355,9 +355,12 @@ class Submission(Resource):
         if documentationUrl is not None:
             submission['documentationUrl'] = documentationUrl
 
-        disqualify = self.boolParam('disqualify', params, default=False)
-        if disqualify:
-            submission['latest'] = False
+        # Note that this does not enforce the requirement that only a single submission
+        # per user per phase is marked as the 'latest' submission. If access to this endpoint
+        # is expanded beyond admin users, then that requirement should be enforced.
+        disqualified = self.boolParam('disqualified', params)
+        if disqualified is not None:
+            submission['latest'] = not disqualified
 
         submission = self.model('submission', 'covalic').save(submission)
 


### PR DESCRIPTION
Add a parameter to the endpoint that updates submission metadata to
enable disqualifying a submission. A disqualified submission will no
longer appear in the leaderboard.