### PR TITLE
Show and hyperlink organization and documentation fields on leaderboard

### DIFF
--- a/web_external/templates/widgets/leaderboard.pug
+++ b/web_external/templates/widgets/leaderboard.pug
@@ -11,7 +11,7 @@ table.table.table-striped.table-condensed.c-leaderboard-table
       th Title
       if enableOrganization
         th Organization
-      if phaseAdmin && enableDocumentationUrl
+      if enableDocumentationUrl
         th Documentation
       th Date
       th Score
@@ -29,12 +29,12 @@ table.table.table-striped.table-condensed.c-leaderboard-table
         td= submission.get('title') || '--'
         if enableOrganization
           td
-            if phaseAdmin && enableOrganizationUrl && submission.get('organizationUrl')
+            if enableOrganizationUrl && submission.get('organizationUrl')
               a.c-organization-link(
                 href=submission.get('organizationUrl'))= submission.get('organization') || '--'
             else
               = submission.get('organization') || '--'
-        if phaseAdmin && enableDocumentationUrl
+        if enableDocumentationUrl
           td
             if submission.get('documentationUrl')
               a.c-documentation-link(href=submission.get('documentationUrl'))


### PR DESCRIPTION
This changes the leaderboard to show and hyperlink the organization and
documentation fields when available, regardless of whether the user is
a phase admin.

Because the API already returns all these fields, only a front-end
change is necessary here.