### PR TITLE
Multiple approaches per user

### DIFF
--- a/plugin.cmake
+++ b/plugin.cmake
@@ -1,12 +1,12 @@
 get_filename_component(PLUGIN ${CMAKE_CURRENT_LIST_DIR} NAME)
 
+add_python_test(submission PLUGIN ${PLUGIN})
 add_python_test(challenge PLUGIN ${PLUGIN})
 add_python_test(challenge_timeframe PLUGIN ${PLUGIN})
 add_python_test(phase PLUGIN ${PLUGIN})
 add_python_test(user_emails PLUGIN ${PLUGIN})
 add_python_test(asset_folder PLUGIN ${PLUGIN})
 add_python_test(submission_folder_access PLUGIN ${PLUGIN})
-add_python_test(submission PLUGIN ${PLUGIN})
 add_python_style_test(python_static_analysis_covalic
                       "${PROJECT_SOURCE_DIR}/plugins/${PLUGIN}/server")
 

--- a/plugin_tests/submission_test.py
+++ b/plugin_tests/submission_test.py
@@ -249,7 +249,7 @@ class SubmissionModelTest(SubmissionBase):
         self.assertEqual(len(submissions), 0)
         submissions = list(self.model('submission', 'covalic').list(
             self.phase1, userFilter=self.admin, approach='default'))
-        self.assertEqual(len(submissions), 1)
+        self.assertEqual(len(submissions), 2)
         submissions = list(self.model('submission', 'covalic').list(
             self.phase1, userFilter=self.user, approach='D'))
         self.assertEqual(len(submissions), 1)
@@ -497,7 +497,7 @@ class SubmissionRestTest(SubmissionBase):
             params={'phaseId': self.phase1['_id'], 'userId': self.user['_id']}
         )
         self.assertStatusOk(resp)
-        self.assertEqual(len(resp.json), 1)
+        self.assertEqual(len(resp.json), 3)
 
     def testListUserApproaches(self):
         userApproaches = ['A', 'C', 'B']

--- a/plugin_tests/submission_test.py
+++ b/plugin_tests/submission_test.py
@@ -127,17 +127,21 @@ class SubmissionBase(base.TestCase):
             submission['score'] = scoreDict
         return self.model('submission', 'covalic').save(submission)
 
-    def generateSubmissionList(self):
+    def generateSubmissionList(self, userApproaches=None, adminApproaches=None):
+        userApproaches = userApproaches or [None, None, None]
+        adminApproaches = adminApproaches or [None, None, None]
         for i in range(3):
             score = [
                 0.25 * (i + 1),
                 0.25 * (4 - i),
             ]
             self.createSubmission(
-                self.phase1, self.user, 'User submission %i phase 1' % i, score=score
+                self.phase1, self.user, 'User submission %i phase 1' % i, score=score,
+                approach=userApproaches[i]
             )
             self.createSubmission(
-                self.phase1, self.admin, 'Admin submission %i phase 1' % i, score=score
+                self.phase1, self.admin, 'Admin submission %i phase 1' % i, score=score,
+                approach=adminApproaches[i]
             )
             self.createSubmission(
                 self.phase2, self.user, 'User submission %i phase 2' % i, score=score
@@ -162,9 +166,23 @@ class SubmissionModelTest(SubmissionBase):
         )
 
         self.assertIsNotNone(submission)
+
+        # 'default' should be injected as the approach, but it should not be present
+        # in the database.
+        self.assertEqual(submission['approach'], 'default')
+        self.assertNotIn('approach', self.model('submission', 'covalic').findOne(submission['_id']))
+
         self.model('submission', 'covalic').remove(submission)
         self.assertIsNone(self.model('submission', 'covalic').findOne(submission['_id']))
         self.assertIsNone(self.model('folder').findOne(submission['folderId']))
+
+    def testCreateWithApproach(self):
+        submission = self.createSubmission(
+            self.phase1, self.user, 'Phase 1 submission',
+            approach='Approach 1'
+        )
+        self.assertIsNotNone(submission)
+        self.assertEqual(submission['approach'], 'approach 1')
 
     def testListSubmissionsByPhase(self):
         self.generateSubmissionList()
@@ -183,6 +201,101 @@ class SubmissionModelTest(SubmissionBase):
         submissions = list(self.model('submission', 'covalic').list(
             self.phase1, latest=True))
         self.assertEqual(len(submissions), 2)
+
+    def testListByApproach(self):
+        userApproaches = ['A', 'C', 'B']
+        adminApproaches = ['A', 'default', 'D']
+        self.generateSubmissionList(
+            userApproaches=userApproaches, adminApproaches=adminApproaches
+        )
+
+        # by approach only
+        submissions = list(self.model('submission', 'covalic').list(
+            self.phase1, approach='default', latest=False))
+        self.assertEqual(len(submissions), 1)
+        submissions = list(self.model('submission', 'covalic').list(
+            self.phase1, approach='A', latest=False))
+        self.assertEqual(len(submissions), 2)
+
+        # by approach and user
+        submissions = list(self.model('submission', 'covalic').list(
+            self.phase1, userFilter=self.user, approach='default', latest=False))
+        self.assertEqual(len(submissions), 0)
+        submissions = list(self.model('submission', 'covalic').list(
+            self.phase1, userFilter=self.admin, approach='default', latest=False))
+        self.assertEqual(len(submissions), 1)
+        submissions = list(self.model('submission', 'covalic').list(
+            self.phase1, userFilter=self.user, approach='A', latest=False))
+        self.assertEqual(len(submissions), 1)
+
+    def testListLatestByApproach(self):
+        userApproaches = ['A', 'A', 'D']
+        adminApproaches = ['default', 'D', 'default']
+        self.generateSubmissionList(
+            userApproaches=userApproaches, adminApproaches=adminApproaches
+        )
+
+        # by approach only
+        submissions = list(self.model('submission', 'covalic').list(
+            self.phase1, approach='default'))
+        self.assertEqual(len(submissions), 1)
+        submissions = list(self.model('submission', 'covalic').list(
+            self.phase1, approach='D'))
+        self.assertEqual(len(submissions), 2)
+
+        # by approach and user
+        submissions = list(self.model('submission', 'covalic').list(
+            self.phase1, userFilter=self.user, approach='default'))
+        self.assertEqual(len(submissions), 0)
+        submissions = list(self.model('submission', 'covalic').list(
+            self.phase1, userFilter=self.admin, approach='default'))
+        self.assertEqual(len(submissions), 1)
+        submissions = list(self.model('submission', 'covalic').list(
+            self.phase1, userFilter=self.user, approach='D'))
+        self.assertEqual(len(submissions), 1)
+
+    def testListSubmissionApproaches(self):
+        userApproaches = ['A', 'C', 'B']
+        adminApproaches = ['A', 'default', 'D']
+        self.generateSubmissionList(
+            userApproaches=userApproaches, adminApproaches=adminApproaches
+        )
+
+        # list all globally
+        self.assertEqual(
+            self.model('submission', 'covalic').listApproaches(),
+            ['a', 'b', 'c', 'd', 'default']
+        )
+
+        # list by phase
+        self.assertEqual(
+            self.model('submission', 'covalic').listApproaches(phase=self.phase1),
+            ['a', 'b', 'c', 'd', 'default']
+        )
+        self.assertEqual(
+            self.model('submission', 'covalic').listApproaches(phase=self.phase2),
+            ['default']
+        )
+
+        # list by user
+        self.assertEqual(
+            self.model('submission', 'covalic').listApproaches(user=self.admin),
+            ['a', 'd', 'default']
+        )
+        self.assertEqual(
+            self.model('submission', 'covalic').listApproaches(user=self.user),
+            ['a', 'b', 'c', 'default']
+        )
+
+        # list by user and phase
+        self.assertEqual(
+            self.model('submission', 'covalic').listApproaches(user=self.admin, phase=self.phase1),
+            ['a', 'd', 'default']
+        )
+        self.assertEqual(
+            self.model('submission', 'covalic').listApproaches(user=self.user, phase=self.phase2),
+            ['default']
+        )
 
     def testRecomputeOverallScores(self):
         self.generateSubmissionList()
@@ -232,6 +345,7 @@ class SubmissionRestTest(SubmissionBase):
         )
         self.assertStatusOk(resp)
         self.assertDictContains({
+            'approach': 'default',
             'created': '2000-01-01T00:00:00+00:00',
             'creatorId': str(self.user['_id']),
             'creatorName': 'First Last',
@@ -245,6 +359,7 @@ class SubmissionRestTest(SubmissionBase):
         resp = self.request(
             path='/covalic_submission/%s' % id, method='PUT', user=self.admin,
             params={
+                'approach': 'A',
                 'title': 'modified title',
                 'date': '2010-01-01 00:00:00',
                 'organization': 'org',
@@ -255,6 +370,7 @@ class SubmissionRestTest(SubmissionBase):
         )
         self.assertStatusOk(resp)
         self.assertDictContains({
+            'approach': 'a',
             'created': '2010-01-01T00:00:00+00:00',
             'title': 'modified title',
             'latest': False,
@@ -289,7 +405,8 @@ class SubmissionRestTest(SubmissionBase):
                 'phaseId': self.phase1['_id'],
                 'folderId': folder['_id'],
                 'title': 'submission phase 1',
-                'date': '2000-01-01 00:00:00'
+                'date': '2000-01-01 00:00:00',
+                'approach': 'A'
             }
         )
         self.assertStatus(resp, 403)
@@ -301,7 +418,8 @@ class SubmissionRestTest(SubmissionBase):
                 'phaseId': self.phase1['_id'],
                 'folderId': folder['_id'],
                 'title': 'submission phase 1',
-                'userId': self.admin['_id']
+                'userId': self.admin['_id'],
+                'approach': 'A'
             }
         )
         self.assertStatus(resp, 403)
@@ -312,7 +430,8 @@ class SubmissionRestTest(SubmissionBase):
             params={
                 'phaseId': self.phase2['_id'],
                 'folderId': folder['_id'],
-                'title': 'submission phase 1'
+                'title': 'submission phase 1',
+                'approach': 'A'
             }
         )
         self.assertStatus(resp, 400)
@@ -324,10 +443,12 @@ class SubmissionRestTest(SubmissionBase):
                 'phaseId': self.phase1['_id'],
                 'folderId': folder['_id'],
                 'title': 'submission phase 1',
+                'approach': 'A'
             }
         )
         self.assertStatusOk(resp)
         self.assertDictContains({
+            'approach': 'a',
             'creatorId': str(self.user['_id']),
             'creatorName': 'First Last',
             'folderId': str(folder['_id']),
@@ -376,7 +497,49 @@ class SubmissionRestTest(SubmissionBase):
             params={'phaseId': self.phase1['_id'], 'userId': self.user['_id']}
         )
         self.assertStatusOk(resp)
-        self.assertEqual(len(resp.json), 3)
+        self.assertEqual(len(resp.json), 1)
+
+    def testListUserApproaches(self):
+        userApproaches = ['A', 'C', 'B']
+        adminApproaches = ['A', 'default', 'D']
+        self.generateSubmissionList(
+            userApproaches=userApproaches, adminApproaches=adminApproaches
+        )
+
+        # all for the current user
+        resp = self.request(path='/covalic_submission/approaches', user=self.admin)
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, ['a', 'd', 'default'])
+        resp = self.request(path='/covalic_submission/approaches', user=self.user)
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, ['a', 'b', 'c', 'default'])
+
+        # by phase for the current user
+        resp = self.request(
+            path='/covalic_submission/approaches', user=self.admin,
+            params={'phaseId': self.phase1['_id']}
+        )
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, ['a', 'd', 'default'])
+        resp = self.request(
+            path='/covalic_submission/approaches', user=self.user,
+            params={'phaseId': self.phase2['_id']}
+        )
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, ['default'])
+
+        # for a specific user
+        resp = self.request(
+            path='/covalic_submission/approaches', user=self.admin,
+            params={'phaseId': self.phase1['_id'], 'userId': self.user['_id']}
+        )
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, ['a', 'b', 'c', 'default'])
+        resp = self.request(
+            path='/covalic_submission/approaches', user=self.user,
+            params={'phaseId': self.phase1['_id'], 'userId': self.admin['_id']}
+        )
+        self.assertStatus(resp, 403)
 
     def testPostScore(self):
         submission = self.createSubmission(self.phase1, self.user, 'submission')

--- a/server/models/submission.py
+++ b/server/models/submission.py
@@ -129,8 +129,7 @@ class Submission(Model):
 
         if userFilter is not None:
             q['creatorId'] = userFilter['_id']
-
-        if latest:
+        elif latest:
             q['latest'] = True
 
         if approach is not None:

--- a/server/rest/submission.py
+++ b/server/rest/submission.py
@@ -40,6 +40,7 @@ class Submission(Resource):
         self.resourceName = 'covalic_submission'
 
         self.route('GET', (), self.listSubmissions)
+        self.route('GET', ('approaches',), self.listUserApproaches)
         self.route('GET', (':id',), self.getSubmission)
         self.route('GET', ('unscored',), self.getUnscoredSubmissions)
         self.route('POST', (), self.postSubmission)
@@ -110,9 +111,11 @@ class Submission(Resource):
                     paramType='query', level=AccessType.READ, required=False, destName='userFilter')
         .param('latest', 'Only include the latest scored submission for each user.',
                required=False, dataType='boolean', default=True)
+        .param('approach', 'Only include this approach in the results',
+               required=False)
         .pagingParams(defaultSort='overallScore', defaultSortDir=SortDir.DESCENDING)
     )
-    def listSubmissions(self, phase, userFilter, latest, limit, offset, sort):
+    def listSubmissions(self, phase, userFilter, latest, limit, offset, sort, approach):
         user = self.getCurrentUser()
 
         # If scores are hidden, do not allow sorting by score fields
@@ -130,8 +133,27 @@ class Submission(Resource):
 
         submissions = self.model('submission', 'covalic').list(
             phase, limit=limit, offset=offset, sort=sort, userFilter=userFilter,
-            fields=fields, latest=latest)
+            fields=fields, latest=latest, approach=approach)
         return [self._filterScore(phase, s, user) for s in submissions]
+
+    @access.user
+    @autoDescribeRoute(
+        Description('List existing approaches for the current user.')
+        .modelParam('phaseId', 'Show only approaches uses in this phase',
+                    model='phase', plugin='covalic', paramType='query',
+                    level=AccessType.READ, required=False, destName='phase')
+        .modelParam('userId', 'Show approaches used by this user (default: current user)',
+                    model='user', paramType='query', level=AccessType.READ,
+                    destName='user', required=False)
+    )
+    def listUserApproaches(self, phase, user):
+        if user is None:
+            user = self.getCurrentUser()
+        else:
+            self.requireAdmin(self.getCurrentUser(),
+                              'Only admins can see other user\'s approaches.')
+
+        return self.model('submission', 'covalic').listApproaches(phase=phase, user=user)
 
     @access.user
     @loadmodel(map={'phaseId': 'phase'}, model='phase', plugin='covalic',
@@ -152,6 +174,7 @@ class Submission(Resource):
                required=False)
         .param('documentationUrl', 'URL of documentation associated with the submission.',
                required=False)
+        .param('approach', 'The submission approach.', required=False)
         .errorResponse('You are not a member of the participant group.', 403)
         .errorResponse('The ID was invalid.')
     )
@@ -182,6 +205,8 @@ class Submission(Resource):
         if phase.get('enableDocumentationUrl', False):
             self._checkRequireParam(phase, params, 'documentationUrl', 'requireDocumentationUrl')
             documentationUrl = self._getStrippedParam(params, 'documentationUrl')
+
+        approach = self._getStrippedParam(params, 'approach')
 
         # Site admins may override the submission creation date
         created = None
@@ -224,7 +249,7 @@ class Submission(Resource):
         title = params['title'].strip()
         submission = self.model('submission', 'covalic').createSubmission(
             user, phase, folder, job, title, created, organization, organizationUrl,
-            documentationUrl)
+            documentationUrl, approach)
 
         if not self.model('phase', 'covalic').hasAccess(
                 phase, user=scoreUser, level=AccessType.ADMIN):
@@ -313,6 +338,7 @@ class Submission(Resource):
                required=False)
         .param('disqualified', 'Whether the submission is disqualified. Disqualified '
                'submissions do not appear in the leaderboard.', dataType='boolean', required=False)
+        .param('approach', 'The submission approach.', required=False)
         .errorResponse('ID was invalid.')
         .errorResponse('Site admin access is required.', 403)
     )
@@ -340,6 +366,9 @@ class Submission(Resource):
         documentationUrl = self._getStrippedParam(params, 'documentationUrl')
         if documentationUrl is not None:
             submission['documentationUrl'] = documentationUrl
+        approach = self._getStrippedParam(params, 'approach')
+        if approach is not None:
+            submission['approach'] = approach
 
         # Note that this does not enforce the requirement that only a single submission
         # per user per phase is marked as the 'latest' submission. If access to this endpoint

--- a/server/rest/submission.py
+++ b/server/rest/submission.py
@@ -139,7 +139,7 @@ class Submission(Resource):
     @access.user
     @autoDescribeRoute(
         Description('List existing approaches for the current user.')
-        .modelParam('phaseId', 'Show only approaches uses in this phase',
+        .modelParam('phaseId', 'Show only approaches used in this phase',
                     model='phase', plugin='covalic', paramType='query',
                     level=AccessType.READ, required=False, destName='phase')
         .modelParam('userId', 'Show approaches used by this user (default: current user)',


### PR DESCRIPTION
This adds the ability for users to submit multiple approaches for each
phase of the challenge.  The approach is stored as a property on the
submission model.  The approach is expected to be an arbitrary string
that is coerced to lower case.

By default, a special approach called "default" is used.  To maintain
backward compatibility with existing databases, the default approach is
stored in the database by the absence of the "approach" key.  The save
and load methods are overridden to handle this behavior at the model
layer.

This also adds a new endpoint to list existing approaches by user and/or
phase.  The list is returned in alphebetical order and "default" is
always injected.

Future work could include adding settings to limit the number of
approaches allowed (even hard code a list of valid approaches) as part
of the model validation.

Depends on #238