### PR TITLE
Add multiple approaches per user in web client

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -9,3 +9,6 @@ webpack:
   main:
     plugin: web_client/main.js
     covalic: web_external/main.js
+npm:
+  dependencies:
+    bootstrap-3-typeahead: ^4.0.2

--- a/plugin_tests/submission_test.py
+++ b/plugin_tests/submission_test.py
@@ -182,7 +182,7 @@ class SubmissionModelTest(SubmissionBase):
             approach='Approach 1'
         )
         self.assertIsNotNone(submission)
-        self.assertEqual(submission['approach'], 'approach 1')
+        self.assertEqual(submission['approach'], 'Approach 1')
 
     def testListSubmissionsByPhase(self):
         self.generateSubmissionList()
@@ -255,8 +255,8 @@ class SubmissionModelTest(SubmissionBase):
         self.assertEqual(len(submissions), 1)
 
     def testListSubmissionApproaches(self):
-        userApproaches = ['A', 'C', 'B']
-        adminApproaches = ['A', 'default', 'D']
+        userApproaches = ['A', 'c', 'b']
+        adminApproaches = ['A', 'default', 'd']
         self.generateSubmissionList(
             userApproaches=userApproaches, adminApproaches=adminApproaches
         )
@@ -264,13 +264,13 @@ class SubmissionModelTest(SubmissionBase):
         # list all globally
         self.assertEqual(
             self.model('submission', 'covalic').listApproaches(),
-            ['a', 'b', 'c', 'd', 'default']
+            ['A', 'b', 'c', 'd', 'default']
         )
 
         # list by phase
         self.assertEqual(
             self.model('submission', 'covalic').listApproaches(phase=self.phase1),
-            ['a', 'b', 'c', 'd', 'default']
+            ['A', 'b', 'c', 'd', 'default']
         )
         self.assertEqual(
             self.model('submission', 'covalic').listApproaches(phase=self.phase2),
@@ -280,17 +280,17 @@ class SubmissionModelTest(SubmissionBase):
         # list by user
         self.assertEqual(
             self.model('submission', 'covalic').listApproaches(user=self.admin),
-            ['a', 'd', 'default']
+            ['A', 'd', 'default']
         )
         self.assertEqual(
             self.model('submission', 'covalic').listApproaches(user=self.user),
-            ['a', 'b', 'c', 'default']
+            ['A', 'b', 'c', 'default']
         )
 
         # list by user and phase
         self.assertEqual(
             self.model('submission', 'covalic').listApproaches(user=self.admin, phase=self.phase1),
-            ['a', 'd', 'default']
+            ['A', 'd', 'default']
         )
         self.assertEqual(
             self.model('submission', 'covalic').listApproaches(user=self.user, phase=self.phase2),
@@ -370,7 +370,7 @@ class SubmissionRestTest(SubmissionBase):
         )
         self.assertStatusOk(resp)
         self.assertDictContains({
-            'approach': 'a',
+            'approach': 'A',
             'created': '2010-01-01T00:00:00+00:00',
             'title': 'modified title',
             'latest': False,
@@ -448,7 +448,7 @@ class SubmissionRestTest(SubmissionBase):
         )
         self.assertStatusOk(resp)
         self.assertDictContains({
-            'approach': 'a',
+            'approach': 'A',
             'creatorId': str(self.user['_id']),
             'creatorName': 'First Last',
             'folderId': str(folder['_id']),
@@ -500,8 +500,8 @@ class SubmissionRestTest(SubmissionBase):
         self.assertEqual(len(resp.json), 3)
 
     def testListUserApproaches(self):
-        userApproaches = ['A', 'C', 'B']
-        adminApproaches = ['A', 'default', 'D']
+        userApproaches = ['A', 'c', 'b']
+        adminApproaches = ['A', 'default', 'd']
         self.generateSubmissionList(
             userApproaches=userApproaches, adminApproaches=adminApproaches
         )
@@ -509,10 +509,10 @@ class SubmissionRestTest(SubmissionBase):
         # all for the current user
         resp = self.request(path='/covalic_submission/approaches', user=self.admin)
         self.assertStatusOk(resp)
-        self.assertEqual(resp.json, ['a', 'd', 'default'])
+        self.assertEqual(resp.json, ['A', 'd', 'default'])
         resp = self.request(path='/covalic_submission/approaches', user=self.user)
         self.assertStatusOk(resp)
-        self.assertEqual(resp.json, ['a', 'b', 'c', 'default'])
+        self.assertEqual(resp.json, ['A', 'b', 'c', 'default'])
 
         # by phase for the current user
         resp = self.request(
@@ -520,7 +520,7 @@ class SubmissionRestTest(SubmissionBase):
             params={'phaseId': self.phase1['_id']}
         )
         self.assertStatusOk(resp)
-        self.assertEqual(resp.json, ['a', 'd', 'default'])
+        self.assertEqual(resp.json, ['A', 'd', 'default'])
         resp = self.request(
             path='/covalic_submission/approaches', user=self.user,
             params={'phaseId': self.phase2['_id']}
@@ -534,7 +534,7 @@ class SubmissionRestTest(SubmissionBase):
             params={'phaseId': self.phase1['_id'], 'userId': self.user['_id']}
         )
         self.assertStatusOk(resp)
-        self.assertEqual(resp.json, ['a', 'b', 'c', 'default'])
+        self.assertEqual(resp.json, ['A', 'b', 'c', 'default'])
         resp = self.request(
             path='/covalic_submission/approaches', user=self.user,
             params={'phaseId': self.phase1['_id'], 'userId': self.admin['_id']}

--- a/plugin_tests/submission_test.py
+++ b/plugin_tests/submission_test.py
@@ -184,6 +184,14 @@ class SubmissionModelTest(SubmissionBase):
         self.assertIsNotNone(submission)
         self.assertEqual(submission['approach'], 'Approach 1')
 
+    def testCreateWithEmptyStringApproach(self):
+        submission = self.createSubmission(
+            self.phase1, self.user, 'Phase 1 submission',
+            approach=''
+        )
+        self.assertIsNotNone(submission)
+        self.assertEqual(submission['approach'], 'default')
+
     def testListSubmissionsByPhase(self):
         self.generateSubmissionList()
         submissions = list(self.model('submission', 'covalic').list(
@@ -226,6 +234,11 @@ class SubmissionModelTest(SubmissionBase):
         self.assertEqual(len(submissions), 1)
         submissions = list(self.model('submission', 'covalic').list(
             self.phase1, userFilter=self.user, approach='A', latest=False))
+        self.assertEqual(len(submissions), 1)
+
+        # approach == '' should be the same as 'default'
+        submissions = list(self.model('submission', 'covalic').list(
+            self.phase1, userFilter=self.admin, approach='', latest=False))
         self.assertEqual(len(submissions), 1)
 
     def testListLatestByApproach(self):

--- a/plugin_tests/submission_test.py
+++ b/plugin_tests/submission_test.py
@@ -541,13 +541,23 @@ class SubmissionRestTest(SubmissionBase):
         self.assertStatusOk(resp)
         self.assertEqual(resp.json, ['default'])
 
-        # for a specific user
+        # for a specific user as admin
         resp = self.request(
             path='/covalic_submission/approaches', user=self.admin,
             params={'phaseId': self.phase1['_id'], 'userId': self.user['_id']}
         )
         self.assertStatusOk(resp)
         self.assertEqual(resp.json, ['A', 'b', 'c', 'default'])
+
+        # for self as non-admin
+        resp = self.request(
+            path='/covalic_submission/approaches', user=self.user,
+            params={'phaseId': self.phase1['_id'], 'userId': self.user['_id']}
+        )
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, ['A', 'b', 'c', 'default'])
+
+        # a normal user cannot query approaches for another user
         resp = self.request(
             path='/covalic_submission/approaches', user=self.user,
             params={'phaseId': self.phase1['_id'], 'userId': self.admin['_id']}

--- a/server/models/submission.py
+++ b/server/models/submission.py
@@ -57,8 +57,6 @@ class Submission(Model):
     def save(self, document, *args, **kwargs):
         if document.get('approach') == 'default':
             del document['approach']
-        if 'approach' in document:
-            document['approach'] = document['approach'].lower()
         document = super(Submission, self).save(document, *args, **kwargs)
         document.setdefault('approach', 'default')
         return document
@@ -133,7 +131,7 @@ class Submission(Model):
             q['latest'] = True
 
         if approach is not None:
-            q['approach'] = approach.lower()
+            q['approach'] = approach
             if approach is 'default':
                 q['approach'] = None
 

--- a/server/models/submission.py
+++ b/server/models/submission.py
@@ -55,8 +55,6 @@ class Submission(Model):
         return doc
 
     def save(self, document, *args, **kwargs):
-        if document.get('approach') == 'default':
-            del document['approach']
         document = super(Submission, self).save(document, *args, **kwargs)
         document.setdefault('approach', 'default')
         return document
@@ -65,7 +63,7 @@ class Submission(Model):
         if doc.get('created'):
             doc['created'] = validateDate(doc.get('created'), 'created')
 
-        if doc.get('approach') == 'default':
+        if doc.get('approach') in {'default', ''}:
             del doc['approach']
 
         if doc.get('score') is not None and doc.get('overallScore') is None:
@@ -132,7 +130,7 @@ class Submission(Model):
 
         if approach is not None:
             q['approach'] = approach
-            if approach is 'default':
+            if approach in {'default', ''}:
                 q['approach'] = None
 
         cursor = self.find(q, limit=limit, offset=offset, sort=sort,

--- a/server/rest/submission.py
+++ b/server/rest/submission.py
@@ -147,11 +147,12 @@ class Submission(Resource):
                     destName='user', required=False)
     )
     def listUserApproaches(self, phase, user):
+        currentUser = self.getCurrentUser()
         if user is None:
-            user = self.getCurrentUser()
-        else:
-            self.requireAdmin(self.getCurrentUser(),
-                              'Only admins can see other user\'s approaches.')
+            user = currentUser
+
+        if user['_id'] != currentUser['_id']:
+            self.requireAdmin(currentUser, 'Only admins can see other user\'s approaches.')
 
         return self.model('submission', 'covalic').listApproaches(phase=phase, user=user)
 

--- a/web_external/models/SubmissionModel.js
+++ b/web_external/models/SubmissionModel.js
@@ -16,7 +16,8 @@ var SubmissionModel = Model.extend({
                 title: opts.title,
                 organization: opts.organization,
                 organizationUrl: opts.organizationUrl,
-                documentationUrl: opts.documentationUrl
+                documentationUrl: opts.documentationUrl,
+                approach: opts.approach || null
             }
         }).done((resp) => {
             this.set(resp);
@@ -42,6 +43,20 @@ var SubmissionModel = Model.extend({
         } else {
             return val;
         }
+    },
+
+    fetchApproaches: function (user, phase) {
+        const data = {};
+        if (user && user.id) {
+            data.userId = user.id;
+        }
+        if (phase && phase.id) {
+            data.phaseId = phase.id;
+        }
+        return restRequest({
+            url: `${this.resourceName}/approaches`,
+            data
+        });
     }
 });
 

--- a/web_external/templates/body/submissionPage.pug
+++ b/web_external/templates/body/submissionPage.pug
@@ -12,7 +12,7 @@
     .c-details-area
       if submission.get('title')
         .c-submission-title-text= submission.get('title')
-      .c-submission-subtitle Submitted #[b= created] by #[b= submission.get('creatorName')]
+      .c-submission-subtitle Submitted #[b= created] by #[b= submission.get('creatorName')] with approach #[b= submission.get('approach')]
 
 .c-submission-display-body
   if download

--- a/web_external/templates/body/submitPage.pug
+++ b/web_external/templates/body/submitPage.pug
@@ -28,6 +28,10 @@
   .form-group
     label Submission title
     input.c-submission-title-input.form-control(type="text", maxlength=maxTextLength)
+  .form-group
+    label Submission approach
+    input.c-submission-approach-input.form-control.typeahead(
+      type='text', data-provide='typeahead', autocomplete='off', value=submission.get('approach'))
   if phase.enableOrganization()
     .form-group
       label

--- a/web_external/templates/body/submitPage.pug
+++ b/web_external/templates/body/submitPage.pug
@@ -18,6 +18,13 @@
     unique, but it will appear in the leaderboard with your submission. The title
     should be no more than #{maxTextLength} characters.
   p.
+    Users are allowed to tag submissions as belonging to a specific "approach" to solving
+    the problem.  Each approach is scored independently and displayed on the leaderboard
+    with the user's name.  The text box below will autocomplete with existing approaches,
+    or you can choose to provide a new approach for this submission.  By default this tag
+    is empty, indicating the standard approach.
+
+  p.
     Use the button below to select all of the files, or drag and drop them onto
     the button. If the selection is valid, you can upload them. Once done, your
     submission is complete and your result will be scored. When the scoring is
@@ -29,7 +36,7 @@
     label Submission title
     input.c-submission-title-input.form-control(type="text", maxlength=maxTextLength)
   .form-group
-    label Submission approach
+    label Submission approach (optional)
     input.c-submission-approach-input.form-control.typeahead(
       type='text', data-provide='typeahead', autocomplete='off', value=approach)
   if phase.enableOrganization()

--- a/web_external/templates/body/submitPage.pug
+++ b/web_external/templates/body/submitPage.pug
@@ -31,7 +31,7 @@
   .form-group
     label Submission approach
     input.c-submission-approach-input.form-control.typeahead(
-      type='text', data-provide='typeahead', autocomplete='off', value=submission.get('approach'))
+      type='text', data-provide='typeahead', autocomplete='off', value=approach)
   if phase.enableOrganization()
     .form-group
       label

--- a/web_external/templates/widgets/leaderboard.pug
+++ b/web_external/templates/widgets/leaderboard.pug
@@ -22,11 +22,13 @@ table.table.table-striped.table-condensed.c-leaderboard-table
       tr.c-stripe(stripe=(rank % 2 ? 'even' : 'odd'))
         th.c-rank= rank
         td
+          - var approachString = submission.get('approach') === 'default' ? '' : ` (${submission.get('approach')})`
           if phaseAdmin
             a.c-user-link(
               href=`#user/${submission.get('creatorId')}`)= submission.get('creatorName')
+            = approachString
           else
-            = submission.get('creatorName')
+            = `${submission.get('creatorName')}${approachString}`
         td= submission.get('title') || '--'
         if enableOrganization
           td

--- a/web_external/views/body/SubmitView.js
+++ b/web_external/views/body/SubmitView.js
@@ -37,7 +37,7 @@ var SubmitView = View.extend({
             this.validateInputs();
         },
         'input .c-submission-approach-input': function (event) {
-            this.submission.set('approach', $(event.currentTarget).val().trim() || 'default');
+            this.approach = $(event.currentTarget).val().trim() || 'default';
             this.validateInputs();
         }
     },
@@ -53,8 +53,9 @@ var SubmitView = View.extend({
         this.organizationUrl = null;
         this.documentationUrl = null;
         this.approaches = [];
-        this.submission = new SubmissionModel({approach: 'default'});
+        this.approach = 'default';
 
+        this.submission = new SubmissionModel();
         this.submission.fetchApproaches(getCurrentUser(), this.phase).done((approaches) => {
             this.approaches = approaches;
             this.render();
@@ -63,6 +64,7 @@ var SubmitView = View.extend({
 
     render: function () {
         this.$el.html(template({
+            approach: this.approach,
             phase: this.phase,
             submission: this.submission,
             approaches: this.approaches,
@@ -208,7 +210,7 @@ var SubmitView = View.extend({
             organization: this.organization,
             organizationUrl: this.organizationUrl,
             documentationUrl: this.documentationUrl,
-            approach: this.submission.get('approach')
+            approach: this.approach
         });
     }
 });

--- a/web_external/views/body/SubmitView.js
+++ b/web_external/views/body/SubmitView.js
@@ -36,10 +36,7 @@ var SubmitView = View.extend({
             this.documentationUrl = $(event.currentTarget).val().trim();
             this.validateInputs();
         },
-        'input .c-submission-approach-input': function (event) {
-            this.approach = $(event.currentTarget).val().trim();
-            this.validateInputs();
-        }
+        'input .c-submission-approach-input': '_updateApproach'
     },
 
     initialize: function (settings) {
@@ -87,7 +84,8 @@ var SubmitView = View.extend({
         this.listenTo(this.uploadWidget, 'g:uploadStarted', this.uploadStarted);
         this.listenTo(this.uploadWidget, 'g:uploadFinished', this.uploadFinished);
         this.$('.c-submission-approach-input').typeahead({
-            source: this.approaches
+            source: this.approaches,
+            afterSelect: () => this._updateApproach()
         });
         return this;
     },
@@ -168,6 +166,10 @@ var SubmitView = View.extend({
         this.filesCorrect = matchInfo.ok;
 
         this.validateInputs();
+    },
+
+    _updateApproach: function () {
+        this.approach = this.$('.c-submission-approach-input').val().trim();
     },
 
     _matchInput: function (inputs, groundtruths) {

--- a/web_external/views/body/SubmitView.js
+++ b/web_external/views/body/SubmitView.js
@@ -92,6 +92,11 @@ var SubmitView = View.extend({
         return this;
     },
 
+    destroy: function () {
+        this.$('.c-submission-approach-input').typeahead('destroy');
+        return View.prototype.destroy.apply(this, arguments);
+    },
+
     /**
      * Validate all text inputs. Enable upload button if inputs valid and
      * uploaded files are valid.

--- a/web_external/views/body/SubmitView.js
+++ b/web_external/views/body/SubmitView.js
@@ -37,7 +37,7 @@ var SubmitView = View.extend({
             this.validateInputs();
         },
         'input .c-submission-approach-input': function (event) {
-            this.approach = $(event.currentTarget).val().trim() || 'default';
+            this.approach = $(event.currentTarget).val().trim();
             this.validateInputs();
         }
     },
@@ -53,7 +53,7 @@ var SubmitView = View.extend({
         this.organizationUrl = null;
         this.documentationUrl = null;
         this.approaches = [];
-        this.approach = 'default';
+        this.approach = null;
 
         this.submission = new SubmissionModel();
         this.submission.fetchApproaches(getCurrentUser(), this.phase).done((approaches) => {

--- a/web_external/views/body/SubmitView.js
+++ b/web_external/views/body/SubmitView.js
@@ -94,7 +94,7 @@ var SubmitView = View.extend({
 
     destroy: function () {
         this.$('.c-submission-approach-input').typeahead('destroy');
-        return View.prototype.destroy.apply(this, arguments);
+        return View.prototype.destroy.call(this);
     },
 
     /**


### PR DESCRIPTION
This makes minimal changes to support the ability to submit multiple
approaches per user.

* SubmissionModel: A new method to fetch existing approaches
* SubmitView: Adds a text input (with autocomplete) to set the approach on the model.  This defaults to `default`.
* LeaderboardView: When listing a non-default approach, the approach name is added in parentheses next to the user name.
* SubmissionView: The approach name is added to the details in the subtitle.

Depends on #239.
