### PR TITLE
Add a metadata object to the submission model

### DIFF
--- a/plugin_tests/submission_test.py
+++ b/plugin_tests/submission_test.py
@@ -636,3 +636,29 @@ class SubmissionRestTest(SubmissionBase):
                 'value': None
             }]
         }])
+
+    def testSubmissionWithMetadata(self):
+        folder = self.model('folder').createFolder(
+            self.admin, 'submission phase 1', parentType='user', creator=self.user
+        )
+        resp = self.request(
+            path='/covalic_submission', method='POST', user=self.user,
+            params={
+                'phaseId': self.phase1['_id'],
+                'folderId': folder['_id'],
+                'title': 'submission phase 1',
+                'meta': '{"test": 1}'
+            }
+        )
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json['meta'], {'test': 1})
+
+        resp = self.request(
+            path='/covalic_submission/%s' % resp.json['_id'],
+            method='PUT', user=self.admin,
+            params={
+                'meta': '{"test2": 2}'
+            }
+        )
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json['meta'], {'test2': 2})

--- a/server/models/submission.py
+++ b/server/models/submission.py
@@ -43,7 +43,7 @@ class Submission(Model):
         self.exposeFields(level=AccessType.READ, fields=(
             '_id', 'creatorId', 'creatorName', 'phaseId', 'folderId', 'created',
             'score', 'title', 'latest', 'overallScore', 'jobId', 'organization', 'organizationUrl',
-            'documentationUrl', 'approach'
+            'documentationUrl', 'approach', 'meta'
         ))
 
     def load(self, *args, **kwargs):
@@ -52,11 +52,14 @@ class Submission(Model):
         if (fields is None or 'approach' in fields) and \
                 doc is not None and doc.get('approach') is None:
             doc['approach'] = 'default'
+        if doc is not None:
+            doc.setdefault('meta', {})
         return doc
 
     def save(self, document, *args, **kwargs):
         document = super(Submission, self).save(document, *args, **kwargs)
         document.setdefault('approach', 'default')
+        document.setdefault('meta', {})
         return document
 
     def validate(self, doc):
@@ -156,7 +159,7 @@ class Submission(Model):
 
     def createSubmission(self, creator, phase, folder, job=None, title=None,
                          created=None, organization=None, organizationUrl=None,
-                         documentationUrl=None, approach=None):
+                         documentationUrl=None, approach=None, meta=None):
         submission = {
             'creatorId': creator['_id'],
             'creatorName': self.getUserName(creator),
@@ -164,7 +167,8 @@ class Submission(Model):
             'folderId': folder['_id'],
             'created': created or datetime.datetime.utcnow(),
             'score': None,
-            'title': title
+            'title': title,
+            'meta': meta or {}
         }
 
         if organization is not None:

--- a/web_external/models/SubmissionModel.js
+++ b/web_external/models/SubmissionModel.js
@@ -17,7 +17,8 @@ var SubmissionModel = Model.extend({
                 organization: opts.organization,
                 organizationUrl: opts.organizationUrl,
                 documentationUrl: opts.documentationUrl,
-                approach: opts.approach || null
+                approach: opts.approach || null,
+                meta: JSON.stringify(opts.meta || {})
             }
         }).done((resp) => {
             this.set(resp);


### PR DESCRIPTION
This is not used directly by covalic.  It is intended to be used by extensions to covalic that will override the submission creation form.