### PR TITLE
Replace deprecated use of .error on $.ajax calls with .fail

### DIFF
--- a/covalic/web_client/views/ConfigView.js
+++ b/covalic/web_client/views/ConfigView.js
@@ -72,17 +72,17 @@ const ConfigView = View.extend({
                 list: JSON.stringify(settings)
             },
             error: null
-        }).done(_.bind(function () {
+        }).done(() => {
             events.trigger('g:alert', {
                 icon: 'ok',
                 text: 'Settings saved.',
                 type: 'success',
                 timeout: 4000
             });
-        }, this)).error(_.bind(function (resp) {
+        }).fail((resp) => {
             this.$('#g-covalic-error-message').text(
                 resp.responseJSON.message);
-        }, this));
+        });
     }
 });
 

--- a/covalic/web_external/models/ChallengeModel.js
+++ b/covalic/web_external/models/ChallengeModel.js
@@ -18,7 +18,7 @@ var ChallengeModel = AccessControlledModel.extend({
             method: 'GET'
         }).done((resp) => {
             this.trigger('c:assetsFolderFetched', resp);
-        }).error((err) => {
+        }).fail((err) => {
             this.trigger('c:error', err);
         });
     },
@@ -36,7 +36,7 @@ var ChallengeModel = AccessControlledModel.extend({
             error: null
         }).done(() => {
             this.trigger('c:thumbnailCreated');
-        }).error((err) => {
+        }).fail((err) => {
             this.trigger('c:error', err);
         });
     },

--- a/covalic/web_external/models/PhaseModel.js
+++ b/covalic/web_external/models/PhaseModel.js
@@ -12,7 +12,7 @@ var PhaseModel = AccessControlledModel.extend({
         }).done((resp) => {
             this.set('groundtruthItems', resp);
             this.trigger('c:groundtruthItemsFetched', resp);
-        }).error((err) => {
+        }).fail((err) => {
             this.trigger('c:error', err);
         });
     },
@@ -36,7 +36,7 @@ var PhaseModel = AccessControlledModel.extend({
             contentType: 'application/json'
         }).done((resp) => {
             this.trigger('c:metricsSaved', resp);
-        }).error((err) => {
+        }).fail((err) => {
             this.trigger('c:error', err);
         });
     },
@@ -50,7 +50,7 @@ var PhaseModel = AccessControlledModel.extend({
         }).done((resp) => {
             this.set(resp);
             this.trigger('c:scoringInfoSaved', resp);
-        }).error((err) => {
+        }).fail((err) => {
             this.trigger('c:error', err);
         });
     },
@@ -61,7 +61,7 @@ var PhaseModel = AccessControlledModel.extend({
             method: 'POST'
         }).done((resp) => {
             this.trigger('c:metricsInitialized', resp);
-        }).error((err) => {
+        }).fail((err) => {
             this.trigger('c:error', err);
         });
     },
@@ -73,7 +73,7 @@ var PhaseModel = AccessControlledModel.extend({
             method: 'DELETE'
         }).done((resp) => {
             this.trigger('c:groundTruthDeleted', resp);
-        }).error((err) => {
+        }).fail((err) => {
             this.trigger('c:error', err);
         });
     },
@@ -85,7 +85,7 @@ var PhaseModel = AccessControlledModel.extend({
             method: 'DELETE'
         }).done((resp) => {
             this.trigger('c:inputDataDeleted', resp);
-        }).error((err) => {
+        }).fail((err) => {
             this.trigger('c:error', err);
         });
     },

--- a/covalic/web_external/models/SubmissionModel.js
+++ b/covalic/web_external/models/SubmissionModel.js
@@ -23,7 +23,7 @@ var SubmissionModel = Model.extend({
         }).done((resp) => {
             this.set(resp);
             this.trigger('c:submissionPosted', resp);
-        }).error((err) => {
+        }).fail((err) => {
             this.trigger('c:error', err);
         });
     },


### PR DESCRIPTION
This removes deprecation warnings on the console.